### PR TITLE
v3.1.5: Add optional start_time and end_time parameters to get_bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migration guides will be provided for all breaking changes
 - Semantic versioning (MAJOR.MINOR.PATCH) is strictly followed
 
+## [3.1.5] - 2025-08-11
+
+### Added
+- **📊 Enhanced Bar Data Retrieval**: Added optional `start_time` and `end_time` parameters to `get_bars()` method
+  - Allows precise time range specification for historical data queries
+  - Parameters override the `days` argument when provided
+  - Supports both timezone-aware and naive datetime objects
+  - Automatically converts times to UTC for API consistency
+  - Smart defaults: `end_time` defaults to now, `start_time` defaults based on `days` parameter
+  - Full backward compatibility maintained - existing code using `days` parameter continues to work
+
+### Tests
+- Added comprehensive test coverage for new time-based parameters
+  - Tests for both `start_time` and `end_time` together
+  - Tests for individual parameter usage
+  - Tests for timezone-aware datetime handling
+  - Tests confirming time parameters override `days` parameter
+
 ## [3.1.4] - 2025-08-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Status: v3.1.4 - Stable Production Release
+## Project Status: v3.1.5 - Stable Production Release
 
 **IMPORTANT**: This project uses a fully asynchronous architecture. All APIs are async-only, optimized for high-performance futures trading.
 
@@ -299,6 +299,12 @@ async with ProjectX.from_env() as client:
 - `cache_max_size = 100` (Indicator cache entries)
 
 ## Recent Changes
+
+### v3.1.5 - Enhanced Bar Data Retrieval
+- **Added**: Optional `start_time` and `end_time` parameters to `get_bars()` method
+- **Improved**: Precise time range specification for historical data queries
+- **Enhanced**: Full timezone support with automatic UTC conversion
+- **Maintained**: Complete backward compatibility with existing `days` parameter
 
 ### v3.1.4 - WebSocket Connection Fix
 - **Fixed**: Critical WebSocket error with missing `_use_batching` attribute

--- a/README.md
+++ b/README.md
@@ -294,8 +294,14 @@ All 58+ indicators work with async data pipelines:
 import polars as pl
 from project_x_py.indicators import RSI, SMA, MACD, FVG, ORDERBLOCK, WAE
 
-# Get data
-data = await client.get_bars("ES", days=30)
+# Get data - multiple ways
+data = await client.get_bars("ES", days=30)  # Last 30 days
+
+# Or use specific time range (v3.1.5+)
+from datetime import datetime
+start = datetime(2025, 1, 1, 9, 30)
+end = datetime(2025, 1, 10, 16, 0)
+data = await client.get_bars("ES", start_time=start, end_time=end)
 
 # Apply traditional indicators
 data = data.pipe(SMA, period=20).pipe(RSI, period=14)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,8 @@ sys.path.insert(0, str(src_dir))
 project = "project-x-py"
 copyright = "2025, Jeff West"
 author = "Jeff West"
-release = "3.1.4"
-version = "3.1.4"
+release = "3.1.5"
+version = "3.1.5"
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-x-py"
-version = "3.1.4"
+version = "3.1.5"
 description = "High-performance Python SDK for futures trading with real-time WebSocket data, technical indicators, order management, and market depth analysis"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/project_x_py/__init__.py
+++ b/src/project_x_py/__init__.py
@@ -95,7 +95,7 @@ from typing import Any
 
 from project_x_py.client.base import ProjectXBase
 
-__version__ = "3.1.4"
+__version__ = "3.1.5"
 __author__ = "TexasCoding"
 
 # Core client classes - renamed from Async* to standard names

--- a/src/project_x_py/indicators/__init__.py
+++ b/src/project_x_py/indicators/__init__.py
@@ -202,7 +202,7 @@ from .candlestick import (
 )
 
 # Version info
-__version__ = "3.1.4"
+__version__ = "3.1.5"
 __author__ = "TexasCoding"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -943,7 +943,7 @@ wheels = [
 
 [[package]]
 name = "project-x-py"
-version = "3.1.3"
+version = "3.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
This PR adds optional `start_time` and `end_time` parameters to the `get_bars()` method, allowing for precise time range specification when retrieving historical market data.

## Changes
- ✨ Added `start_time` and `end_time` optional parameters to `get_bars()` method
- 🔧 Parameters override the `days` argument when provided
- 🌍 Full support for timezone-aware and naive datetime objects
- 🔄 Automatic conversion to UTC for API consistency
- 📊 Smart defaults: `end_time` defaults to now, `start_time` uses `days` parameter
- ✅ Full backward compatibility maintained - existing code continues to work

## Testing
- Added 5 comprehensive test cases covering all scenarios:
  - Both `start_time` and `end_time` together
  - Only `start_time` (end defaults to now)
  - Only `end_time` (start defaults based on `days`)
  - Timezone-aware datetime handling
  - Verification that time parameters override `days`

## Documentation
- Updated CHANGELOG.md with v3.1.5 release notes
- Updated README.md with usage example
- Updated CLAUDE.md with latest version info

## Example Usage
```python
# Traditional usage still works
data = await client.get_bars("ES", days=30)

# New time-based parameters
from datetime import datetime
start = datetime(2025, 1, 1, 9, 30)
end = datetime(2025, 1, 10, 16, 0)
data = await client.get_bars("ES", start_time=start, end_time=end)
```

## Breaking Changes
None - full backward compatibility maintained