### PR TITLE
fix: preserve gateway trade commissions & normalize trade response fields

### DIFF
--- a/src/project_x_py/client/trading.py
+++ b/src/project_x_py/client/trading.py
@@ -77,6 +77,15 @@ from project_x_py.utils.deprecation import deprecated
 
 logger = logging.getLogger(__name__)
 
+_TRADE_FIELDS = frozenset(Trade.__slots__)
+
+
+def _trade_from_response(data: dict[str, Any]) -> Trade:
+    values = dict(data)
+    if "fees" not in values and "commissions" in values:
+        values["fees"] = values["commissions"]
+    return Trade(**{field: values[field] for field in _TRADE_FIELDS if field in values})
+
 
 class TradingMixin:
     """Mixin class providing trading functionality."""
@@ -273,4 +282,4 @@ class TradingMixin:
         if not response or not isinstance(response, list):
             return []
 
-        return [Trade(**trade) for trade in response]
+        return [_trade_from_response(trade) for trade in response]

--- a/src/project_x_py/models.py
+++ b/src/project_x_py/models.py
@@ -455,7 +455,7 @@ class Position:
             return 0.0
 
 
-@dataclass
+@dataclass(slots=True)
 class Trade:
     """
     Represents an executed trade with P&L information.
@@ -468,6 +468,7 @@ class Trade:
         price (float): Execution price
         profitAndLoss (Optional[float]): Realized P&L (None for half-turn trades)
         fees (float): Trading fees/commissions
+        commissions (Optional[float]): Gateway commission amount, if provided
         side (int): Trade side: 0=Buy, 1=Sell
         size (int): Number of contracts traded
         voided (bool): Whether the trade was voided/cancelled
@@ -483,20 +484,6 @@ class Trade:
         >>> print(f"{side_str} {trade.size} @ ${trade.price} - P&L: {pnl_str}")
     """
 
-    __slots__ = (
-        "accountId",
-        "contractId",
-        "creationTimestamp",
-        "fees",
-        "id",
-        "orderId",
-        "price",
-        "profitAndLoss",
-        "side",
-        "size",
-        "voided",
-    )
-
     id: int
     accountId: int
     contractId: str
@@ -508,6 +495,7 @@ class Trade:
     size: int
     voided: bool
     orderId: int
+    commissions: float | None = None
 
 
 @dataclass

--- a/src/project_x_py/types/api_responses.py
+++ b/src/project_x_py/types/api_responses.py
@@ -144,7 +144,8 @@ class TradeResponse(TypedDict):
     creationTimestamp: str
     price: float
     profitAndLoss: NotRequired[float]  # None for half-turn trades
-    fees: float
+    fees: NotRequired[float]
+    commissions: NotRequired[float]
     side: int  # 0=Buy, 1=Sell
     size: int
     voided: bool

--- a/tests/client/test_trading_legacy.py
+++ b/tests/client/test_trading_legacy.py
@@ -394,6 +394,43 @@ class TestTradingMixin:
         assert call_args[1]["params"]["limit"] == 50
 
     @pytest.mark.asyncio
+    async def test_search_trades_preserves_gateway_commissions_field(
+        self, trading_client
+    ):
+        """Test trade search keeps Gateway commissions while setting fees."""
+        trading_client.account_info = Account(
+            id=12345,
+            name="Test Account",
+            balance=10000.0,
+            canTrade=True,
+            isVisible=True,
+            simulated=False,
+        )
+
+        trading_client._make_request.return_value = [
+            {
+                "id": 1,
+                "accountId": 12345,
+                "contractId": "MNQ",
+                "creationTimestamp": datetime.datetime.now(pytz.UTC).isoformat(),
+                "price": 15000.0,
+                "profitAndLoss": 75.0,
+                "commissions": 2.25,
+                "side": 0,
+                "size": 3,
+                "voided": False,
+                "orderId": 102,
+                "extraField": "ignored",
+            }
+        ]
+
+        trades = await trading_client.search_trades(contract_id="MNQ")
+
+        assert len(trades) == 1
+        assert trades[0].fees == 2.25
+        assert trades[0].commissions == 2.25
+
+    @pytest.mark.asyncio
     async def test_search_trades_custom_account_id(self, trading_client):
         """Test trade search with custom account ID."""
         # No account_info, use explicit account_id

--- a/tests/types/test_api_responses.py
+++ b/tests/types/test_api_responses.py
@@ -129,7 +129,7 @@ class TestAPIResponseTypes:
         assert "side" in hints
         assert hints["side"] is int
         assert "fees" in hints
-        assert hints["fees"] is float
+        assert "commissions" in hints
 
         # Optional P&L (None for half-turn trades)
         assert "profitAndLoss" in hints

--- a/tests/types/test_models.py
+++ b/tests/types/test_models.py
@@ -183,6 +183,23 @@ class TestTradeModel:
         # Access attributes
         assert t.price == pytest.approx(5000.0)
         assert t.profitAndLoss is None  # half-turn trade allowed
+        assert t.commissions is None
+
+        t_with_commissions = Trade(
+            id=8,
+            accountId=10,
+            contractId="CON.F.US.MNQ.H25",
+            creationTimestamp="2024-01-01T00:01:00Z",
+            price=5001.0,
+            profitAndLoss=10.0,
+            fees=2.5,
+            side=1,
+            size=1,
+            voided=False,
+            orderId=124,
+            commissions=2.5,
+        )
+        assert t_with_commissions.commissions == pytest.approx(2.5)
 
         # __slots__ should prevent setting unknown attributes
         with pytest.raises(AttributeError):


### PR DESCRIPTION
## Summary

Makes `search_trades()` resilient to Gateway trade payload variants while preserving Gateway commission data.

## Root Cause

Some Gateway trade search responses return `commissions` instead of `fees`, and may include additional fields not accepted by the SDK `Trade` model. Passing the raw payload directly to `Trade(**trade)` can raise `TypeError`, and mapping `commissions` only into `fees` would hide a Gateway field callers may need.

## Changes

- Adds optional `Trade.commissions`.
- Adds optional `commissions` to `TradeResponse`.
- Keeps existing `fees` compatibility by populating `fees` from `commissions` when `fees` is absent.
- Ignores unknown future response fields that are not part of the `Trade` model.
- Adds regression coverage for preserving Gateway `commissions`.

## Scope

This PR is trade response normalization and model support only. It does not change the trade search endpoint or position response handling.

Related PRs:
- #86 fixes the Gateway trade search endpoint and request shape.
- #88 handles Gateway position `contractDisplayName`.

## Validation

- `uv run pytest tests/client/test_trading.py tests/client/test_trading_legacy.py tests/types/test_models.py tests/types/test_api_responses.py -q`
- `uv run ruff check src/project_x_py/client/trading.py src/project_x_py/models.py src/project_x_py/types/api_responses.py tests/client/test_trading_legacy.py tests/types/test_models.py tests/types/test_api_responses.py`
- `uv run ruff format --check src/project_x_py/client/trading.py src/project_x_py/models.py src/project_x_py/types/api_responses.py tests/client/test_trading_legacy.py tests/types/test_models.py tests/types/test_api_responses.py`
- `uv run mypy src/project_x_py/client/trading.py src/project_x_py/models.py src/project_x_py/types/api_responses.py`
