### PR TITLE
feat: support direct credentials in TradingSuite.create

### DIFF
--- a/src/project_x_py/trading_suite.py
+++ b/src/project_x_py/trading_suite.py
@@ -471,6 +471,9 @@ class TradingSuite:
             timeframes: Data timeframes (default: ["5min"])
             features: Optional features to enable
             session_config: Optional session configuration
+            username: Optional ProjectX username. Must be used with api_key.
+            api_key: Optional ProjectX API key. Must be used with username.
+            account_name: Optional account name to select during authentication
             **kwargs: Additional configuration options
 
         Returns:
@@ -507,6 +510,16 @@ class TradingSuite:
                 "Must provide either 'instruments' or 'instrument' parameter"
             )
 
+        username = cast(str | None, kwargs.pop("username", None))
+        api_key = cast(str | None, kwargs.pop("api_key", None))
+        account_name = cast(str | None, kwargs.pop("account_name", None))
+
+        if (username is None) != (api_key is None):
+            raise ValueError(
+                "Both 'username' and 'api_key' must be provided for direct "
+                "TradingSuite authentication"
+            )
+
         # Build configuration using primary instrument
         config = TradingSuiteConfig(
             instrument=primary_instrument,
@@ -517,7 +530,15 @@ class TradingSuite:
         )
 
         # Create and authenticate client
-        client_context = ProjectX.from_env()
+        client_context: AbstractAsyncContextManager[ProjectXBase]
+        if username is not None and api_key is not None:
+            client_context = ProjectX(
+                username=username,
+                api_key=api_key,
+                account_name=account_name.upper() if account_name else None,
+            )
+        else:
+            client_context = ProjectX.from_env(account_name=account_name)
         client = await client_context.__aenter__()
 
         try:

--- a/tests/trading_suite/test_core.py
+++ b/tests/trading_suite/test_core.py
@@ -12,6 +12,25 @@ from project_x_py import Features, TradingSuite, TradingSuiteConfig
 from project_x_py.models import Account
 
 
+def _mock_authenticated_client() -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.account_info = Account(
+        id=12345,
+        name="TEST_ACCOUNT",
+        balance=100000.0,
+        canTrade=True,
+        isVisible=True,
+        simulated=True,
+    )
+    mock_client.session_token = "mock_jwt_token"
+    mock_client.config = MagicMock()
+    mock_client.authenticate = AsyncMock()
+    mock_client.get_instrument = AsyncMock(return_value=MagicMock(id="MNQ_CONTRACT_ID"))
+    mock_client.search_all_orders = AsyncMock(return_value=[])
+    mock_client.search_open_positions = AsyncMock(return_value=[])
+    return mock_client
+
+
 @pytest.mark.asyncio
 async def test_trading_suite_create():
     """Test basic TradingSuite creation with mocked client."""
@@ -123,6 +142,68 @@ async def test_trading_suite_create():
                     # Verify cleanup
                     assert suite._connected is False
                     assert suite._initialized is False
+
+
+@pytest.mark.asyncio
+async def test_trading_suite_create_with_direct_credentials():
+    """Test TradingSuite creation with directly supplied ProjectX credentials."""
+
+    mock_client = _mock_authenticated_client()
+
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_client
+    mock_context.__aexit__.return_value = None
+
+    mock_realtime = MagicMock()
+    mock_realtime.disconnect = AsyncMock(return_value=None)
+
+    mock_data_manager = MagicMock()
+    mock_data_manager.stop_realtime_feed = AsyncMock(return_value=None)
+    mock_data_manager.cleanup = AsyncMock(return_value=None)
+
+    mock_position_manager = MagicMock()
+
+    with patch(
+        "project_x_py.trading_suite.ProjectX", return_value=mock_context
+    ) as mock_project_x:
+        with patch(
+            "project_x_py.trading_suite.ProjectXRealtimeClient",
+            return_value=mock_realtime,
+        ):
+            with patch(
+                "project_x_py.trading_suite.RealtimeDataManager",
+                return_value=mock_data_manager,
+            ):
+                with patch(
+                    "project_x_py.trading_suite.PositionManager",
+                    return_value=mock_position_manager,
+                ):
+                    suite = await TradingSuite.create(
+                        "MNQ",
+                        username="direct_user",
+                        api_key="direct_key",
+                        account_name="test_account",
+                        auto_connect=False,
+                    )
+
+                    mock_project_x.assert_called_once_with(
+                        username="direct_user",
+                        api_key="direct_key",
+                        account_name="TEST_ACCOUNT",
+                    )
+                    assert suite.client == mock_client
+                    assert suite.config.auto_connect is False
+
+                    await suite.disconnect()
+                    mock_context.__aexit__.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trading_suite_create_requires_direct_credentials_together():
+    """Test direct credentials fail early when partially supplied."""
+
+    with pytest.raises(ValueError, match="Both 'username' and 'api_key'"):
+        await TradingSuite.create("MNQ", username="direct_user")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow TradingSuite.create to accept direct ProjectX username/api_key credentials
- forward account_name to direct or environment-backed client creation instead of TradingSuiteConfig
- add regression coverage for direct credentials and partial credential validation

## Why
TradingSuite.create accepted arbitrary kwargs for suite configuration and always created its ProjectX client with ProjectX.from_env(). Callers that supplied username, api_key, or account_name had those values forwarded into TradingSuiteConfig, causing an unexpected keyword argument failure before market data could initialize.

## Validation
- uv run pytest tests/trading_suite/test_core.py -q
- uv run ruff check src/project_x_py/trading_suite.py tests/trading_suite/test_core.py
- uv run ruff format --check src/project_x_py/trading_suite.py tests/trading_suite/test_core.py