### PR TITLE
fix: honor platform symlink resolution in mmap overflow path validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migration guides will be provided for all breaking changes
 - Semantic versioning (MAJOR.MINOR.PATCH) is strictly followed
 
+## [Unreleased]
+
+### 🐛 Fixed
+
+**Realtime Data Manager**:
+- **MMap overflow silently disabled on macOS**: the overflow storage path
+  security validation did not account for platform symlink resolution
+  (macOS resolves `/tmp` to `/private/tmp`), so legitimate temp-directory
+  paths were rejected and memory-mapped disk overflow was silently disabled.
+  The allowlist now includes the resolved system temp directory
+  (`tempfile.gettempdir()`) and `/private/tmp`.
+- **Silent disable severity**: an invalid overflow storage path now logs at
+  ERROR level (previously WARNING), since it disables a data-safety feature.
+
 ## [3.5.8] - 2025-09-02
 
 ### 🐛 Fixed

--- a/src/project_x_py/realtime_data_manager/mmap_overflow.py
+++ b/src/project_x_py/realtime_data_manager/mmap_overflow.py
@@ -6,6 +6,7 @@ when in-memory limits are reached, preventing memory exhaustion while
 maintaining fast access to recent data.
 """
 
+import tempfile
 from contextlib import suppress
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -76,9 +77,13 @@ class MMapOverflowMixin:
             # Additional security check - ensure resolved path is in safe locations
             path_str = str(self.mmap_storage_path)
             home_str = str(Path.home())
-            # Include both /var/folders and /private/var/folders for macOS temp directories
+            # Include the resolved system temp directory so platform symlink
+            # resolution is honored (e.g. macOS resolves /tmp -> /private/tmp),
+            # plus /var/folders and /private/var/folders for macOS temp dirs.
             temp_dirs = [
+                str(Path(tempfile.gettempdir()).resolve()),
                 "/tmp",  # nosec B108 - needed for temp file validation
+                "/private/tmp",  # nosec B108 - macOS resolves /tmp here
                 "/var/folders",
                 "/private/var/folders",
                 str(Path.cwd()),
@@ -101,7 +106,7 @@ class MMapOverflowMixin:
             if "traversal" in str(e):
                 raise
             # For other invalid paths (unsafe or non-existent), disable overflow
-            logger.warning(f"Invalid overflow storage path, disabling overflow: {e}")
+            logger.error(f"Invalid overflow storage path, disabling overflow: {e}")
             self.enable_mmap_overflow = False
         except Exception as e:
             logger.error(f"Failed to create overflow storage directory: {e}")


### PR DESCRIPTION
On macOS, Path.resolve() maps /tmp to /private/tmp, which was missing from the overflow storage path allowlist. Legitimate temp-directory paths were therefore rejected and memory-mapped disk overflow was silently disabled, removing a data-safety protection without notice.

- Allowlist now includes the resolved system temp directory (tempfile.gettempdir()) and /private/tmp
- Escalate the silent-disable log from WARNING to ERROR, since an invalid path disables a data-safety feature
- Directory traversal protection is unchanged

Fixes the 3 failing tests in
tests/realtime_data_manager/test_mmap_overflow.py on macOS (test_mixin_initialization_with_valid_path,
test_check_overflow_needed_above_threshold,
test_overflow_threshold_configuration).