### PR TITLE
fix: serialize hub send so multi-instrument create does not race (#126)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "89a6cfe2a229151e8055abee107d45ed087bbb4f",
         "is_verified": false,
-        "line_number": 2395
+        "line_number": 2408
       }
     ],
     "README.md": [
@@ -216,5 +216,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-30T15:20:59Z"
+  "generated_at": "2026-08-30T18:19:40Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 None.
 
+## [4.1.1] - 2026-08-30
+
+### Fixed
+
+- Serialize SignalR hub `send()` so concurrent market subscriptions cannot
+  overlap on the shared pysignalr client (#126).
+- `TradingSuite.create(["MNQ", "MES"])` subscribes all contracts in one
+  market-hub call, then starts feeds. `start_realtime_feed` skips a second
+  subscribe when the contract is already tracked.
+- Health-monitor heartbeats await async hub `send()` instead of dropping the
+  coroutine (`RuntimeWarning: coroutine 'AsyncHubConnection.send' was never
+  awaited`).
+
 ## [4.1.0] - 2026-08-30
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ A **high-performance async Python SDK** for the [ProjectX Trading Platform](http
 
 This Python SDK acts as a bridge between your trading strategies and the ProjectX platform, handling all the complex API interactions, data processing, and real-time connectivity.
 
-## 🚀 v4.1.0 - Gateway coverage and live-trading hardening
+## 🚀 v4.1.1 - Multi-instrument market-hub subscribe race
 
-**Latest Version**: v4.1.0 — TopstepX-only, aligned with the current Gateway HTTP and SignalR APIs, with risk OCO, entry-order risk gating, and honest indicator/docs claims.
+**Latest Version**: v4.1.1 — TopstepX-only Gateway SDK. v4.1.1 fixes `TradingSuite.create(["MNQ", "MES"])` racing the shared SignalR market hub (`Subscription returned False` / un-awaited `send()`). v4.1.0 added risk OCO, entry-order risk gating, and honest indicator/docs claims.
 
 **Key changes**:
 - Official defaults: `https://api.topstepx.com` and `https://rtc.topstepx.com`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The canonical changelog is the repository root [CHANGELOG.md](https://github.com/TexasCoding/project-x-py/blob/main/CHANGELOG.md). This page is a docs-site copy.
 
+## [4.1.1] - 2026-08-30
+
+Fix multi-instrument `TradingSuite.create()` racing the shared market-hub
+`send()` (`Subscription returned False`). See the root CHANGELOG for the
+full list.
+
 ## [4.1.0] - 2026-08-30
 
 Gateway coverage, live-trading risk OCO and entry-order gating, realtime stale-feed/batching/DST fixes, and honest indicator/docs claims. See the root CHANGELOG for the full list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@
 
 **project-x-py** is a high-performance **async Python SDK** for the [ProjectX Trading Platform](https://www.projectx.com/) Gateway API. This library enables developers to build sophisticated trading strategies and applications by providing comprehensive async access to futures trading operations, real-time market data, Level 2 orderbook analysis, and 64 named indicators (Polars implementations; **not** a full TA-Lib port).
 
-!!! note "Version 4.1.0"
-    **Latest Release**: TopstepX-only Gateway SDK (`api.topstepx.com` / `rtc.topstepx.com`) with native brackets, risk OCO and entry-order gating, stale-feed watchdog, `OrderSubmissionUncertainError`, and 64 named Polars indicators (not a full TA-Lib port). See the [v3 → v4 migration guide](migration/v3-to-v4.md).
+!!! note "Version 4.1.1"
+    **Latest Release**: TopstepX-only Gateway SDK (`api.topstepx.com` / `rtc.topstepx.com`) with native brackets, risk OCO and entry-order gating, stale-feed watchdog, `OrderSubmissionUncertainError`, and 64 named Polars indicators (not a full TA-Lib port). v4.1.1 serializes market-hub `send()` so multi-instrument `TradingSuite.create(["MNQ", "MES"])` no longer races subscriptions. See the [v3 → v4 migration guide](migration/v3-to-v4.md).
 
 !!! note "Stable Production Release"
     This project maintains strict semantic versioning. v4.0.0 is a major release with documented breaking changes. Deprecation warnings are provided for at least 2 minor versions before removal.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
-# ProjectX Python SDK Examples (v4.1.0)
+# ProjectX Python SDK Examples (v4.1.1)
 
-This directory contains working examples for the ProjectX Python SDK v4.1.0. All examples use **MNQ (Micro E-mini NASDAQ)** contracts to minimize risk during testing.
+This directory contains working examples for the ProjectX Python SDK v4.1.1. All examples use **MNQ (Micro E-mini NASDAQ)** contracts to minimize risk during testing.
 
 **Note:** v4.0 is the TopstepX Gateway revival. Use `TradingSuite.create()`, `await suite.get_stats()` / `export_stats()`, and see `docs/migration/v3-to-v4.md` for breaking changes.
 

--- a/src/project_x_py/__init__.py
+++ b/src/project_x_py/__init__.py
@@ -3,7 +3,7 @@ ProjectX Python SDK for Trading Applications
 
 Author: @TexasCoding
 Date: 2026-08-29
-Version: 4.1.0 - Gateway coverage and live-trading hardening
+Version: 4.1.1 - Multi-instrument market-hub subscribe race (#126)
 
 Overview:
     A comprehensive Python SDK for the ProjectX Trading Platform Gateway API, providing
@@ -96,7 +96,7 @@ Architecture Benefits:
 It provides the infrastructure to help developers create their own trading applications
 that integrate with the ProjectX platform.
 
-Version: 4.1.0
+Version: 4.1.1
 Author: TexasCoding
 
 See Also:
@@ -109,7 +109,7 @@ See Also:
     - `utils`: Utility functions and calculations
 """
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 __author__ = "TexasCoding"
 
 # Core client classes - renamed from Async* to standard names

--- a/src/project_x_py/client/http.py
+++ b/src/project_x_py/client/http.py
@@ -158,7 +158,7 @@ class HttpMixin:
             verify=True,
             follow_redirects=False,
             headers={
-                "User-Agent": "ProjectX-Python-SDK/4.1.0",
+                "User-Agent": "ProjectX-Python-SDK/4.1.1",
                 "Accept": "application/json",
             },
         )

--- a/src/project_x_py/indicators/__init__.py
+++ b/src/project_x_py/indicators/__init__.py
@@ -206,7 +206,7 @@ from .candlestick import (
 )
 
 # Version info
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 __author__ = "TexasCoding"
 
 

--- a/src/project_x_py/realtime/async_hub.py
+++ b/src/project_x_py/realtime/async_hub.py
@@ -43,6 +43,7 @@ class AsyncHubConnection:
         self._close_handlers: list[Callable[[], Any]] = []
         self._error_handlers: list[Callable[[Any], Any]] = []
         self._event_handlers: dict[str, list[Callable[..., Any]]] = {}
+        self._send_lock = asyncio.Lock()
 
     def _token_factory(self) -> str:
         parsed = urlparse(self.url)
@@ -130,7 +131,8 @@ class AsyncHubConnection:
 
     async def send(self, method: str, arguments: list[Any] | None = None) -> None:
         client = self._ensure_client()
-        await client.send(method, arguments or [])
+        async with self._send_lock:
+            await client.send(method, arguments or [])
 
 
 class HubConnectionBuilder:

--- a/src/project_x_py/realtime/connection_management.py
+++ b/src/project_x_py/realtime/connection_management.py
@@ -403,6 +403,10 @@ class ConnectionManagementMixin:
                     await invoke_maybe(self.market_connection.stop)
                     self.market_connected = False
 
+                live = getattr(self, "_live_market_subscriptions", None)
+                if isinstance(live, set):
+                    live.clear()
+
                 logger.debug(LogMessages.WS_DISCONNECTED)
 
     # Connection event handlers

--- a/src/project_x_py/realtime/core.py
+++ b/src/project_x_py/realtime/core.py
@@ -375,6 +375,7 @@ class ProjectXRealtimeClient(
         # Track subscribed contracts for reconnection
         self._subscribed_contracts: list[str] = []
         self._user_updates_subscribed: bool = False
+        self._subscription_lock = asyncio.Lock()
 
         # Logger
         self.logger = logging.getLogger(__name__)

--- a/src/project_x_py/realtime/core.py
+++ b/src/project_x_py/realtime/core.py
@@ -374,6 +374,7 @@ class ProjectXRealtimeClient(
 
         # Track subscribed contracts for reconnection
         self._subscribed_contracts: list[str] = []
+        self._live_market_subscriptions: set[str] = set()
         self._user_updates_subscribed: bool = False
         self._subscription_lock = asyncio.Lock()
 

--- a/src/project_x_py/realtime/health_monitoring.py
+++ b/src/project_x_py/realtime/health_monitoring.py
@@ -110,6 +110,7 @@ from collections import deque
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from project_x_py.realtime.async_hub import invoke_maybe
 from project_x_py.utils import (
     LogContext,
     ProjectXLogger,
@@ -440,25 +441,16 @@ class HealthMonitoringMixin:
             self._total_heartbeats_sent += 1
 
             # Send ping - SignalR connections typically have a ping method
-            # If not available, we'll use a custom heartbeat message
-            try:
-                # Try SignalR's built-in ping method
-                ping_method = getattr(connection, "ping", None)
-                if ping_method:
-                    await asyncio.get_event_loop().run_in_executor(None, ping_method)
-                else:
-                    # Send custom heartbeat message
-                    await asyncio.get_event_loop().run_in_executor(
-                        None,
-                        lambda: connection.send(
-                            "Heartbeat", {"timestamp": time.time()}
-                        ),
-                    )
-            except AttributeError:
-                # Fallback to custom heartbeat
-                await asyncio.get_event_loop().run_in_executor(
-                    None,
-                    lambda: connection.send("Heartbeat", {"timestamp": time.time()}),
+            # If not available, we'll use a custom heartbeat message.
+            # AsyncHubConnection.send is async; always await it (#126).
+            ping_method = getattr(connection, "ping", None)
+            if callable(ping_method):
+                await invoke_maybe(ping_method)
+            else:
+                await invoke_maybe(
+                    connection.send,
+                    "Heartbeat",
+                    [{"timestamp": time.time()}],
                 )
 
             # Calculate latency

--- a/src/project_x_py/realtime/subscriptions.py
+++ b/src/project_x_py/realtime/subscriptions.py
@@ -79,6 +79,15 @@ if TYPE_CHECKING:
 logger = ProjectXLogger.get_logger(__name__)
 
 
+def _live_market_subscriptions(client: "ProjectXRealtimeClientProtocol") -> set[str]:
+    """Contracts whose SubscribeContract* sends completed on this hub session."""
+    live = getattr(client, "_live_market_subscriptions", None)
+    if not isinstance(live, set):
+        live = set()
+        client._live_market_subscriptions = live
+    return live
+
+
 class SubscriptionsMixin:
     """Mixin for subscription management functionality."""
 
@@ -293,6 +302,7 @@ class SubscriptionsMixin:
                             "SubscribeContractMarketDepth",
                             [contract_id],
                         )
+                        _live_market_subscriptions(self).add(contract_id)
                     except Exception as e:
                         logger.error(
                             LogMessages.WS_ERROR,
@@ -442,9 +452,11 @@ class SubscriptionsMixin:
 
             async with lock:
                 # Remove from stored contracts
+                live = _live_market_subscriptions(self)
                 for contract_id in contract_ids:
                     if contract_id in self._subscribed_contracts:
                         self._subscribed_contracts.remove(contract_id)
+                    live.discard(contract_id)
 
                 if self.market_connection is None:
                     logger.error(

--- a/src/project_x_py/realtime/subscriptions.py
+++ b/src/project_x_py/realtime/subscriptions.py
@@ -258,41 +258,49 @@ class SubscriptionsMixin:
                 extra={"channel": "market_data", "count": len(contract_ids)},
             )
 
-            # Store for reconnection (avoid duplicates)
-            for contract_id in contract_ids:
-                if contract_id not in self._subscribed_contracts:
-                    self._subscribed_contracts.append(contract_id)
+            lock = getattr(self, "_subscription_lock", None)
+            if lock is None:
+                self._subscription_lock = asyncio.Lock()
+                lock = self._subscription_lock
 
-            for contract_id in contract_ids:
-                if self.market_connection is None:
-                    logger.error(
-                        LogMessages.WS_ERROR,
-                        extra={"error": "Market connection not available"},
-                    )
-                    return False
+            async with lock:
+                # Store for reconnection (avoid duplicates)
+                for contract_id in contract_ids:
+                    if contract_id not in self._subscribed_contracts:
+                        self._subscribed_contracts.append(contract_id)
 
-                try:
-                    await invoke_maybe(
-                        self.market_connection.send,
-                        "SubscribeContractQuotes",
-                        [contract_id],
-                    )
-                    await invoke_maybe(
-                        self.market_connection.send,
-                        "SubscribeContractTrades",
-                        [contract_id],
-                    )
-                    await invoke_maybe(
-                        self.market_connection.send,
-                        "SubscribeContractMarketDepth",
-                        [contract_id],
-                    )
-                except Exception as e:
-                    logger.error(
-                        LogMessages.WS_ERROR,
-                        extra={"error": f"Failed to subscribe to {contract_id}: {e!s}"},
-                    )
-                    return False
+                for contract_id in contract_ids:
+                    if self.market_connection is None:
+                        logger.error(
+                            LogMessages.WS_ERROR,
+                            extra={"error": "Market connection not available"},
+                        )
+                        return False
+
+                    try:
+                        await invoke_maybe(
+                            self.market_connection.send,
+                            "SubscribeContractQuotes",
+                            [contract_id],
+                        )
+                        await invoke_maybe(
+                            self.market_connection.send,
+                            "SubscribeContractTrades",
+                            [contract_id],
+                        )
+                        await invoke_maybe(
+                            self.market_connection.send,
+                            "SubscribeContractMarketDepth",
+                            [contract_id],
+                        )
+                    except Exception as e:
+                        logger.error(
+                            LogMessages.WS_ERROR,
+                            extra={
+                                "error": f"Failed to subscribe to {contract_id}: {e!s}"
+                            },
+                        )
+                        return False
 
             logger.debug(
                 LogMessages.DATA_SUBSCRIBE,
@@ -427,34 +435,40 @@ class SubscriptionsMixin:
                 extra={"channel": "market_data", "count": len(contract_ids)},
             )
 
-            # Remove from stored contracts
-            for contract_id in contract_ids:
-                if contract_id in self._subscribed_contracts:
-                    self._subscribed_contracts.remove(contract_id)
+            lock = getattr(self, "_subscription_lock", None)
+            if lock is None:
+                self._subscription_lock = asyncio.Lock()
+                lock = self._subscription_lock
 
-            if self.market_connection is None:
-                logger.error(
-                    LogMessages.WS_ERROR,
-                    extra={"error": "Market connection not available"},
-                )
-                return False
+            async with lock:
+                # Remove from stored contracts
+                for contract_id in contract_ids:
+                    if contract_id in self._subscribed_contracts:
+                        self._subscribed_contracts.remove(contract_id)
 
-            for contract_id in contract_ids:
-                await invoke_maybe(
-                    self.market_connection.send,
-                    "UnsubscribeContractQuotes",
-                    [contract_id],
-                )
-                await invoke_maybe(
-                    self.market_connection.send,
-                    "UnsubscribeContractTrades",
-                    [contract_id],
-                )
-                await invoke_maybe(
-                    self.market_connection.send,
-                    "UnsubscribeContractMarketDepth",
-                    [contract_id],
-                )
+                if self.market_connection is None:
+                    logger.error(
+                        LogMessages.WS_ERROR,
+                        extra={"error": "Market connection not available"},
+                    )
+                    return False
+
+                for contract_id in contract_ids:
+                    await invoke_maybe(
+                        self.market_connection.send,
+                        "UnsubscribeContractQuotes",
+                        [contract_id],
+                    )
+                    await invoke_maybe(
+                        self.market_connection.send,
+                        "UnsubscribeContractTrades",
+                        [contract_id],
+                    )
+                    await invoke_maybe(
+                        self.market_connection.send,
+                        "UnsubscribeContractMarketDepth",
+                        [contract_id],
+                    )
 
             logger.debug(
                 LogMessages.DATA_UNSUBSCRIBE,

--- a/src/project_x_py/realtime_data_manager/core.py
+++ b/src/project_x_py/realtime_data_manager/core.py
@@ -1041,13 +1041,22 @@ class RealtimeDataManager(
                 self._on_trade_update,  # Use market_trade event name
             )
 
-            # Subscribe to market data using the contract ID
+            # Subscribe to market data using the contract ID.
+            # TradingSuite already subscribes once for all instruments; skip the
+            # second hub send when this contract is already tracked (#126).
             self.logger.debug(
                 LogMessages.DATA_SUBSCRIBE, extra={"contract_id": self.contract_id}
             )
-            subscription_success = await self.realtime_client.subscribe_market_data(
-                [self.contract_id]
+            subscribed = getattr(self.realtime_client, "_subscribed_contracts", None)
+            already_subscribed = isinstance(subscribed, list | tuple | set) and (
+                self.contract_id in subscribed
             )
+            if already_subscribed:
+                subscription_success = True
+            else:
+                subscription_success = await self.realtime_client.subscribe_market_data(
+                    [self.contract_id]
+                )
 
             if not subscription_success:
                 raise ProjectXError(

--- a/src/project_x_py/realtime_data_manager/core.py
+++ b/src/project_x_py/realtime_data_manager/core.py
@@ -1042,14 +1042,14 @@ class RealtimeDataManager(
             )
 
             # Subscribe to market data using the contract ID.
-            # TradingSuite already subscribes once for all instruments; skip the
-            # second hub send when this contract is already tracked (#126).
+            # Skip a second hub send only after a successful SubscribeContract*
+            # on this session (#126). Desired-set membership is not enough.
             self.logger.debug(
                 LogMessages.DATA_SUBSCRIBE, extra={"contract_id": self.contract_id}
             )
-            subscribed = getattr(self.realtime_client, "_subscribed_contracts", None)
-            already_subscribed = isinstance(subscribed, list | tuple | set) and (
-                self.contract_id in subscribed
+            live = getattr(self.realtime_client, "_live_market_subscriptions", None)
+            already_subscribed = isinstance(live, set | list | tuple) and (
+                self.contract_id in live
             )
             if already_subscribed:
                 subscription_success = True

--- a/src/project_x_py/statistics/__init__.py
+++ b/src/project_x_py/statistics/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
     "CleanupScheduler",
 ]
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"

--- a/src/project_x_py/trading_suite.py
+++ b/src/project_x_py/trading_suite.py
@@ -900,29 +900,40 @@ class TradingSuite:
             raise
 
     async def _initialize_instrument_contexts(self) -> None:
-        """Initialize all instrument contexts in parallel."""
+        """Initialize all instrument contexts.
 
-        async def _initialize_single_context(context: InstrumentContext) -> None:
-            """Initialize a single instrument context."""
-            # Initialize order manager with realtime client for order tracking
+        Historical data and manager setup can run in parallel. Market-hub
+        subscribe is a single call for every contract so concurrent
+        ``send()`` on the shared SignalR client cannot race (#126).
+        """
+
+        async def _prepare_context(context: InstrumentContext) -> None:
+            """Initialize managers and historical data for one instrument."""
             await context.orders.initialize(realtime_client=self.realtime)
-
-            # Initialize position manager with order manager for cleanup
             await context.positions.initialize(
                 realtime_client=self.realtime,
                 order_manager=context.orders,
             )
-
-            # Load historical data
             await context.data.initialize(initial_days=self.config.initial_days)
 
-            # Subscribe to market data
-            await self.realtime.subscribe_market_data([context.instrument_info.id])
+        await asyncio.gather(
+            *[_prepare_context(context) for context in self._instruments.values()]
+        )
 
-            # Start realtime data feed
+        contract_ids = [
+            context.instrument_info.id for context in self._instruments.values()
+        ]
+        subscribed = await self.realtime.subscribe_market_data(contract_ids)
+        if not subscribed:
+            from project_x_py.exceptions import ProjectXError
+
+            raise ProjectXError(
+                "Failed to subscribe to market data: Subscription returned False"
+            )
+
+        async def _start_context_feed(context: InstrumentContext) -> None:
+            """Start the realtime feed and optional orderbook after subscribe."""
             await context.data.start_realtime_feed()
-
-            # Initialize optional components
             if context.orderbook:
                 await context.orderbook.initialize(
                     realtime_client=self.realtime,
@@ -930,12 +941,9 @@ class TradingSuite:
                     subscribe_to_quotes=True,
                 )
 
-        # Initialize all contexts in parallel
-        tasks = [
-            _initialize_single_context(context)
-            for context in self._instruments.values()
-        ]
-        await asyncio.gather(*tasks)
+        await asyncio.gather(
+            *[_start_context_feed(context) for context in self._instruments.values()]
+        )
 
         # Update statistics aggregator with components
         if self._is_single_instrument and self._single_context:

--- a/src/project_x_py/types/protocols.py
+++ b/src/project_x_py/types/protocols.py
@@ -618,6 +618,7 @@ class ProjectXRealtimeClientProtocol(Protocol):
 
     # Subscriptions
     _subscribed_contracts: list[str]
+    _live_market_subscriptions: set[str]
     _user_updates_subscribed: bool
 
     # Logging

--- a/src/project_x_py/types/protocols.py
+++ b/src/project_x_py/types/protocols.py
@@ -626,6 +626,7 @@ class ProjectXRealtimeClientProtocol(Protocol):
     # Async locks and events
     _callback_lock: asyncio.Lock
     _connection_lock: asyncio.Lock
+    _subscription_lock: asyncio.Lock
     user_hub_ready: asyncio.Event
     market_hub_ready: asyncio.Event
 

--- a/tests/realtime/test_async_hub.py
+++ b/tests/realtime/test_async_hub.py
@@ -1,7 +1,11 @@
 """Tests for the pysignalr hub adapter."""
 
+import asyncio
+
+import pytest
+
 from project_x_py.realtime import async_hub
-from project_x_py.realtime.async_hub import HubConnectionBuilder
+from project_x_py.realtime.async_hub import AsyncHubConnection, HubConnectionBuilder
 
 
 def test_hub_receive_buffer_is_capped() -> None:
@@ -55,3 +59,36 @@ def test_hub_task_name_does_not_include_access_token() -> None:
     assert connection.hub_name == "user"
     assert "access_token" not in f"hub:{connection.hub_name}"
     assert connection.url.startswith("https://rtc.topstepx.com/hubs/user")
+
+
+@pytest.mark.asyncio
+async def test_send_serializes_concurrent_calls() -> None:
+    """Issue #126: overlapping send() on one hub must not race pysignalr."""
+    connection = AsyncHubConnection(
+        "https://example.test/hubs/market", hub_name="market"
+    )
+    in_flight = 0
+    max_in_flight = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class FakeClient:
+        async def send(self, method: str, arguments: list) -> None:
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            started.set()
+            await release.wait()
+            in_flight -= 1
+
+    connection._client = FakeClient()
+
+    first = asyncio.create_task(connection.send("SubscribeContractQuotes", ["MNQ"]))
+    await started.wait()
+    second = asyncio.create_task(connection.send("SubscribeContractQuotes", ["MES"]))
+    # Give the second send a chance to overlap if there is no lock.
+    await asyncio.sleep(0.02)
+    assert max_in_flight == 1
+    release.set()
+    await asyncio.gather(first, second)
+    assert max_in_flight == 1

--- a/tests/realtime/test_health_monitoring.py
+++ b/tests/realtime/test_health_monitoring.py
@@ -212,33 +212,22 @@ class TestHeartbeatMechanism:
 
     async def test_send_heartbeat_with_ping_method(self, health_client):
         """Test heartbeat using SignalR ping method when available."""
-        # Mock ping method
         health_client.user_connection.ping = MagicMock()
 
-        with patch("asyncio.get_event_loop") as mock_loop:
-            mock_loop.return_value.run_in_executor = AsyncMock()
+        await health_client._send_heartbeat("user")
 
-            await health_client._send_heartbeat("user")
-
-            # Should use ping method
-            mock_loop.return_value.run_in_executor.assert_called()
+        health_client.user_connection.ping.assert_called()
+        assert health_client._total_heartbeats_sent == 1
 
     async def test_send_heartbeat_failure(self, health_client):
         """Test heartbeat failure handling."""
-        # Make send method raise exception
-        health_client.user_connection.send = MagicMock(
+        health_client.user_connection.ping = MagicMock(
             side_effect=Exception("Connection failed")
         )
 
-        with patch("asyncio.get_event_loop") as mock_loop:
-            mock_loop.return_value.run_in_executor = AsyncMock(
-                side_effect=Exception("Connection failed")
-            )
+        await health_client._send_heartbeat("user")
 
-            await health_client._send_heartbeat("user")
-
-            # Should record failure
-            assert health_client._user_heartbeats_failed == 1
+        assert health_client._user_heartbeats_failed == 1
 
     async def test_send_heartbeat_when_disconnected(self, health_client):
         """Test heartbeat skipped when hub is disconnected."""
@@ -248,6 +237,24 @@ class TestHeartbeatMechanism:
 
         # Should not increment heartbeat counter
         assert health_client._total_heartbeats_sent == 0
+
+    async def test_send_heartbeat_awaits_async_send(self, health_client):
+        """Issue #126: AsyncHubConnection.send must be awaited, not dropped."""
+        sent: list[tuple[str, object]] = []
+
+        async def async_send(method: str, arguments=None) -> None:
+            sent.append((method, arguments))
+            await asyncio.sleep(0)
+
+        health_client.user_connection = Mock(spec=["send"])
+        health_client.user_connection.send = async_send
+
+        await health_client._send_heartbeat("user")
+
+        assert sent, "async send() was never awaited"
+        assert sent[0][0] == "Heartbeat"
+        assert health_client._total_heartbeats_sent == 1
+        assert len(health_client._user_latencies) == 1
 
     async def test_heartbeat_high_latency_warning(self, health_client):
         """Test warning logged for high latency heartbeats."""

--- a/tests/realtime/test_subscriptions.py
+++ b/tests/realtime/test_subscriptions.py
@@ -270,6 +270,17 @@ class TestMarketSubscriptions:
         assert "NQ" in subscription_handler._subscribed_contracts
         assert "YM" in subscription_handler._subscribed_contracts
 
+        # Restore/reconnect still needs hub send for already-tracked ids (#126)
+        subscription_handler.market_connection.send.assert_any_call(
+            "SubscribeContractQuotes", ["ES"]
+        )
+        subscription_handler.market_connection.send.assert_any_call(
+            "SubscribeContractTrades", ["ES"]
+        )
+        subscription_handler.market_connection.send.assert_any_call(
+            "SubscribeContractMarketDepth", ["ES"]
+        )
+
     @pytest.mark.asyncio
     async def test_subscribe_market_data_market_not_connected(
         self, subscription_handler

--- a/tests/realtime/test_subscriptions.py
+++ b/tests/realtime/test_subscriptions.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
 
+from project_x_py.realtime.async_hub import AsyncHubConnection
 from project_x_py.realtime.subscriptions import SubscriptionsMixin
 
 
@@ -453,6 +454,38 @@ class TestSubscriptionEdgeCases:
 
         # All should succeed
         assert all(results)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_subscribe_does_not_overlap_hub_send(
+        self, subscription_handler
+    ):
+        """Issue #126: concurrent subscribe_market_data must serialize hub send()."""
+        in_flight = 0
+        max_in_flight = 0
+        connection = AsyncHubConnection(
+            "https://example.test/hubs/market", hub_name="market"
+        )
+
+        class FakeClient:
+            async def send(self, method: str, arguments: list) -> None:
+                nonlocal in_flight, max_in_flight
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                await asyncio.sleep(0.02)
+                in_flight -= 1
+
+        connection._client = FakeClient()
+        subscription_handler.market_connection = connection
+
+        results = await asyncio.gather(
+            subscription_handler.subscribe_market_data(["MNQ"]),
+            subscription_handler.subscribe_market_data(["MES"]),
+        )
+
+        assert all(results)
+        assert max_in_flight == 1
+        assert "MNQ" in subscription_handler._subscribed_contracts
+        assert "MES" in subscription_handler._subscribed_contracts
 
     @pytest.mark.asyncio
     async def test_subscription_state_consistency(self, subscription_handler):

--- a/tests/realtime_data_manager/test_data_core_comprehensive.py
+++ b/tests/realtime_data_manager/test_data_core_comprehensive.py
@@ -519,6 +519,36 @@ class TestRealtimeDataManagerWebSocketOperations:
             await manager.start_realtime_feed()
 
     @pytest.mark.asyncio
+    async def test_start_realtime_feed_skips_resubscribe_when_already_subscribed(
+        self,
+    ):
+        """Issue #126: start_realtime_feed is idempotent if the contract is live."""
+        project_x = Mock(spec=ProjectXBase)
+        realtime_client = AsyncMock(spec=ProjectXRealtimeClient)
+
+        realtime_client.is_connected.return_value = True
+        realtime_client.subscribe_market_data.return_value = True
+        realtime_client._subscribed_contracts = ["test-contract-id"]
+
+        manager = RealtimeDataManager("MNQ", project_x, realtime_client)
+        manager.contract_id = "test-contract-id"
+        manager._initialized = True
+
+        with (
+            patch.object(manager, "start_cleanup_task"),
+            patch.object(manager, "_start_bar_timer_task"),
+            patch.object(manager, "start_resource_monitoring"),
+        ):
+            result = await manager.start_realtime_feed()
+
+        assert result is True
+        assert manager.is_running is True
+        realtime_client.subscribe_market_data.assert_not_called()
+        realtime_client.add_callback.assert_any_call(
+            "quote_update", manager._on_quote_update
+        )
+
+    @pytest.mark.asyncio
     async def test_stop_realtime_feed_successful(self):
         """Test successful stop of realtime feed."""
         project_x = Mock(spec=ProjectXBase)

--- a/tests/realtime_data_manager/test_data_core_comprehensive.py
+++ b/tests/realtime_data_manager/test_data_core_comprehensive.py
@@ -519,16 +519,17 @@ class TestRealtimeDataManagerWebSocketOperations:
             await manager.start_realtime_feed()
 
     @pytest.mark.asyncio
-    async def test_start_realtime_feed_skips_resubscribe_when_already_subscribed(
+    async def test_start_realtime_feed_skips_resubscribe_when_live_on_hub(
         self,
     ):
-        """Issue #126: start_realtime_feed is idempotent if the contract is live."""
+        """Issue #126: skip re-subscribe only after a successful hub send."""
         project_x = Mock(spec=ProjectXBase)
         realtime_client = AsyncMock(spec=ProjectXRealtimeClient)
 
         realtime_client.is_connected.return_value = True
         realtime_client.subscribe_market_data.return_value = True
         realtime_client._subscribed_contracts = ["test-contract-id"]
+        realtime_client._live_market_subscriptions = {"test-contract-id"}
 
         manager = RealtimeDataManager("MNQ", project_x, realtime_client)
         manager.contract_id = "test-contract-id"
@@ -546,6 +547,33 @@ class TestRealtimeDataManagerWebSocketOperations:
         realtime_client.subscribe_market_data.assert_not_called()
         realtime_client.add_callback.assert_any_call(
             "quote_update", manager._on_quote_update
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_realtime_feed_retries_after_failed_subscribe(self):
+        """Desired-set membership must not hide a failed hub send."""
+        project_x = Mock(spec=ProjectXBase)
+        realtime_client = AsyncMock(spec=ProjectXRealtimeClient)
+
+        realtime_client.is_connected.return_value = True
+        realtime_client.subscribe_market_data.return_value = True
+        realtime_client._subscribed_contracts = ["test-contract-id"]
+        realtime_client._live_market_subscriptions = set()
+
+        manager = RealtimeDataManager("MNQ", project_x, realtime_client)
+        manager.contract_id = "test-contract-id"
+        manager._initialized = True
+
+        with (
+            patch.object(manager, "start_cleanup_task"),
+            patch.object(manager, "_start_bar_timer_task"),
+            patch.object(manager, "start_resource_monitoring"),
+        ):
+            result = await manager.start_realtime_feed()
+
+        assert result is True
+        realtime_client.subscribe_market_data.assert_called_once_with(
+            ["test-contract-id"]
         )
 
     @pytest.mark.asyncio

--- a/tests/trading_suite/test_multi_instrument.py
+++ b/tests/trading_suite/test_multi_instrument.py
@@ -184,6 +184,111 @@ async def test_multi_instrument_suite_creation():
 
 
 @pytest.mark.asyncio
+async def test_multi_instrument_create_subscribes_once_then_starts_feeds():
+    """Issue #126: one market-hub subscribe for all contracts, then start feeds."""
+    mock_client = MagicMock()
+    mock_client.account_info = Account(
+        id=12345,
+        name="TEST_ACCOUNT",
+        balance=100000.0,
+        canTrade=True,
+        isVisible=True,
+        simulated=True,
+    )
+    mock_client.session_token = "mock_jwt_token"
+    mock_client.config = MagicMock()
+    mock_client.authenticate = AsyncMock()
+
+    instruments = {
+        "MNQ": MagicMock(id="CON.F.US.MNQ.U26", symbol="MNQ"),
+        "MES": MagicMock(id="CON.F.US.MES.U26", symbol="MES"),
+    }
+
+    async def mock_get_instrument(symbol: str):
+        return instruments[symbol]
+
+    mock_client.get_instrument = AsyncMock(side_effect=mock_get_instrument)
+    mock_client.search_all_orders = AsyncMock(return_value=[])
+    mock_client.search_open_positions = AsyncMock(return_value=[])
+
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_client
+    mock_context.__aexit__.return_value = None
+
+    call_order: list[tuple[str, object]] = []
+
+    mock_realtime = MagicMock()
+    mock_realtime.connect = AsyncMock(return_value=True)
+    mock_realtime.disconnect = AsyncMock(return_value=None)
+    mock_realtime.subscribe_user_updates = AsyncMock(return_value=True)
+    mock_realtime.is_connected.return_value = True
+
+    async def track_subscribe(contract_ids):
+        call_order.append(("subscribe", list(contract_ids)))
+        return True
+
+    mock_realtime.subscribe_market_data = AsyncMock(side_effect=track_subscribe)
+
+    def create_mock_data_manager(instrument, **kwargs):
+        mock_dm = MagicMock()
+        mock_dm.initialize = AsyncMock(return_value=True)
+
+        async def start_feed():
+            call_order.append(("start_feed", instrument))
+            return True
+
+        mock_dm.start_realtime_feed = AsyncMock(side_effect=start_feed)
+        mock_dm.stop_realtime_feed = AsyncMock(return_value=None)
+        mock_dm.cleanup = AsyncMock(return_value=None)
+        return mock_dm
+
+    def create_mock_position_manager(*args, **kwargs):
+        mock_pm = MagicMock()
+        mock_pm.initialize = AsyncMock(return_value=True)
+        mock_pm.get_all_positions = AsyncMock(return_value=[])
+        return mock_pm
+
+    with patch(
+        "project_x_py.trading_suite.ProjectX.from_env", return_value=mock_context
+    ):
+        with patch(
+            "project_x_py.trading_suite.ProjectXRealtimeClient",
+            return_value=mock_realtime,
+        ):
+            with patch(
+                "project_x_py.trading_suite.RealtimeDataManager",
+                side_effect=create_mock_data_manager,
+            ):
+                with patch(
+                    "project_x_py.trading_suite.PositionManager",
+                    side_effect=create_mock_position_manager,
+                ):
+                    suite = await TradingSuite.create(
+                        instruments=["MNQ", "MES"],
+                        timeframes=["1min", "5min"],
+                    )
+
+                    subscribe_calls = [
+                        item for item in call_order if item[0] == "subscribe"
+                    ]
+                    start_calls = [
+                        item for item in call_order if item[0] == "start_feed"
+                    ]
+
+                    assert len(subscribe_calls) == 1
+                    assert set(subscribe_calls[0][1]) == {
+                        "CON.F.US.MNQ.U26",
+                        "CON.F.US.MES.U26",
+                    }
+                    assert len(start_calls) == 2
+                    first_subscribe = call_order.index(subscribe_calls[0])
+                    first_start = min(call_order.index(c) for c in start_calls)
+                    assert first_subscribe < first_start
+
+                    await suite.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_backward_compatibility_single_instrument():
     """
     RED: Test that single-instrument access still works with deprecation warnings.

--- a/tests/trading_suite/test_multi_instrument.py
+++ b/tests/trading_suite/test_multi_instrument.py
@@ -289,6 +289,95 @@ async def test_multi_instrument_create_subscribes_once_then_starts_feeds():
 
 
 @pytest.mark.asyncio
+async def test_multi_instrument_create_raises_when_subscribe_fails():
+    """Issue #126: failed market subscribe must not start feeds."""
+    from project_x_py.exceptions import ProjectXError
+
+    mock_client = MagicMock()
+    mock_client.account_info = Account(
+        id=12345,
+        name="TEST_ACCOUNT",
+        balance=100000.0,
+        canTrade=True,
+        isVisible=True,
+        simulated=True,
+    )
+    mock_client.session_token = "mock_jwt_token"
+    mock_client.config = MagicMock()
+    mock_client.authenticate = AsyncMock()
+
+    instruments = {
+        "MNQ": MagicMock(id="CON.F.US.MNQ.U26", symbol="MNQ"),
+        "MES": MagicMock(id="CON.F.US.MES.U26", symbol="MES"),
+    }
+
+    async def mock_get_instrument(symbol: str):
+        return instruments[symbol]
+
+    mock_client.get_instrument = AsyncMock(side_effect=mock_get_instrument)
+    mock_client.search_all_orders = AsyncMock(return_value=[])
+    mock_client.search_open_positions = AsyncMock(return_value=[])
+
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_client
+    mock_context.__aexit__.return_value = None
+
+    mock_realtime = MagicMock()
+    mock_realtime.connect = AsyncMock(return_value=True)
+    mock_realtime.disconnect = AsyncMock(return_value=None)
+    mock_realtime.subscribe_user_updates = AsyncMock(return_value=True)
+    mock_realtime.subscribe_market_data = AsyncMock(return_value=False)
+    mock_realtime.is_connected.return_value = True
+
+    started: list[str] = []
+
+    def create_mock_data_manager(instrument, **kwargs):
+        mock_dm = MagicMock()
+        mock_dm.initialize = AsyncMock(return_value=True)
+
+        async def start_feed():
+            started.append(instrument)
+            return True
+
+        mock_dm.start_realtime_feed = AsyncMock(side_effect=start_feed)
+        mock_dm.stop_realtime_feed = AsyncMock(return_value=None)
+        mock_dm.cleanup = AsyncMock(return_value=None)
+        return mock_dm
+
+    def create_mock_position_manager(*args, **kwargs):
+        mock_pm = MagicMock()
+        mock_pm.initialize = AsyncMock(return_value=True)
+        mock_pm.get_all_positions = AsyncMock(return_value=[])
+        return mock_pm
+
+    with patch(
+        "project_x_py.trading_suite.ProjectX.from_env", return_value=mock_context
+    ):
+        with patch(
+            "project_x_py.trading_suite.ProjectXRealtimeClient",
+            return_value=mock_realtime,
+        ):
+            with patch(
+                "project_x_py.trading_suite.RealtimeDataManager",
+                side_effect=create_mock_data_manager,
+            ):
+                with patch(
+                    "project_x_py.trading_suite.PositionManager",
+                    side_effect=create_mock_position_manager,
+                ):
+                    with pytest.raises(
+                        ProjectXError, match="Subscription returned False"
+                    ):
+                        await TradingSuite.create(
+                            instruments=["MNQ", "MES"],
+                            timeframes=["1min"],
+                        )
+
+                    assert started == []
+                    mock_realtime.disconnect.assert_awaited()
+
+
+@pytest.mark.asyncio
 async def test_backward_compatibility_single_instrument():
     """
     RED: Test that single-instrument access still works with deprecation warnings.


### PR DESCRIPTION
## Summary
Fixes #126: `TradingSuite.create(["MNQ", "MES"])` flaked with `Subscription returned False` and `coroutine 'AsyncHubConnection.send' was never awaited` because parallel instrument init piled `send()` onto one shared pysignalr market hub.

## Changes
- Serialize `AsyncHubConnection.send()` with an `asyncio.Lock`.
- Subscribe every contract in one `subscribe_market_data([...])` call, then start feeds (do not `gather` per-instrument subscribe).
- `start_realtime_feed` skips a second hub subscribe when the contract is already tracked.
- Health-monitor heartbeats `await` async hub `send()` instead of dropping the coroutine via `run_in_executor`.
- Market subscribe/unsubscribe take `_subscription_lock` for list mutations.
- Bump to **v4.1.1** (PATCH). Changelog, README, docs, examples, and User-Agent updated.

Reconnect restore still re-sends `SubscribeContract*` because skip is only in `start_realtime_feed`, not in `subscribe_market_data`.

## Tests
Local: `uv run pytest tests/ --ignore=tests/benchmarks/` → **3166 passed, 2 skipped**.

New coverage:
- concurrent hub `send()` never overlaps
- concurrent `subscribe_market_data` serializes send
- `start_realtime_feed` does not re-subscribe when already tracked
- suite create subscribes once (both contracts) then starts feeds
- heartbeat awaits async `send()`

## Release
This PR is the v4.1.1 release candidate. After CI is green, squash-merge, tag `v4.1.1`, GitHub Release, and PyPI publish.