### PR TITLE
fix: bound get_session_data so on_bar cannot hang (#137)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "CHANGELOG.md",
         "hashed_secret": "89a6cfe2a229151e8055abee107d45ed087bbb4f",
         "is_verified": false,
-        "line_number": 2451
+        "line_number": 2471
       }
     ],
     "README.md": [
@@ -216,5 +216,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T00:29:40Z"
+  "generated_at": "2026-09-04T03:47:41Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 None.
 
+## [4.2.1] - 2026-09-03
+
+### Fixed
+
+- `get_session_data()` / `get_data()` no longer wait forever on the bar-cache
+  lock. `AsyncRWLock` now actually blocks readers while a writer holds or is
+  waiting, write locks are re-entrant, and acquisition is cancellable. Session
+  reads copy bars under a bounded lock (default 2s) then filter after release.
+  On timeout the last successful snapshot is returned when one exists, else
+  `None`, so an `on_bar` handler cannot stall the event loop (#137).
+
+### Added
+
+- `get_session_data(..., timeout=)` and `get_data(..., timeout=)`. Defaults
+  come from `DataManagerConfig.session_data_timeout` (2.0s) and
+  `data_lock_timeout` (5.0s).
+- `resolve_session_product()` maps Gateway ids (`CON.F.US.MNQ.H26`) and
+  month codes (`MNQH26`) to session calendars. `session_type` on
+  `get_session_data()` is optional and defaults to `session_config`.
+
 ## [4.2.0] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ A **high-performance async Python SDK** for the [ProjectX Trading Platform](http
 
 This Python SDK acts as a bridge between your trading strategies and the ProjectX platform, handling all the complex API interactions, data processing, and real-time connectivity.
 
-## 🚀 v4.2.0 - Rolling-contract history and stats watchdog fix
+## 🚀 v4.2.1 - Session data no longer hangs on bar-cache lock
 
-**Latest Version**: v4.2.0 — `get_bars()` pages the 20,000-bar Gateway cap and stitches expired months on hourly+ product-root requests. Sub-hour history is still the active contract only (Gateway limitation). `suite.get_stats()` no longer re-enters itself or leaks tasks (#133, #134). v4.1.2 stopped market-hub WS 1009 close-loops and Practice `live=True` lookup misses.
+**Latest Version**: v4.2.1 — `get_session_data()` copies bars under a bounded lock (default 2s) and returns the last snapshot on timeout, so `on_bar` cannot stall (#137). v4.2.0 paged `get_bars()` at the 20,000-bar cap, stitched expired months on hourly+ product-root requests, and stopped `suite.get_stats()` from re-entering itself (#133, #134).
 
 **Key changes**:
 - Official defaults: `https://api.topstepx.com` and `https://rtc.topstepx.com`
@@ -263,9 +263,9 @@ async def session_example():
         session_config=SessionConfig(session_type=SessionType.ETH)
     )
 
-    # v3.5.0: Use explicit instrument access
-    rth_data = await rth_suite["MNQ"].data.get_session_data("1min")
-    eth_data = await eth_suite["MNQ"].data.get_session_data("1min")
+    # session_type defaults to session_config; pass it to override
+    rth_data = await rth_suite["MNQ"].data.get_session_data("1min", SessionType.RTH)
+    eth_data = await eth_suite["MNQ"].data.get_session_data("1min", SessionType.ETH)
 
     print(f"RTH bars: {len(rth_data):,}")  # ~390 bars per day
     print(f"ETH bars: {len(eth_data):,}")  # ~1,410 bars per day (366% more)
@@ -279,7 +279,7 @@ if __name__ == "__main__":
 
 ⚠️ **Note**: Session filtering is experimental. Test thoroughly in paper trading before production use.
 
-📚 **Full Example**: See `examples/sessions/16_eth_vs_rth_sessions_demo.py` for comprehensive demonstration of all session features.
+📚 **Full Example**: See `examples/sessions/00_eth_vs_rth_sessions_demo.py` for a walkthrough of session filtering.
 
 ### Trading Suite (Enhanced in v3.5.0)
 

--- a/docs/api/data-manager.md
+++ b/docs/api/data-manager.md
@@ -50,28 +50,19 @@ async def accessing_bar_data():
     suite = await TradingSuite.create(["MNQ"], timeframes=["1min", "5min"])
     mnq_data = suite["MNQ"].data
 
-    # Get data for a specific timeframe
+    # Get data for a specific timeframe (copy of the in-memory cache)
     bars = await mnq_data.get_data("1min")
     if bars is not None and not bars.is_empty():
         print(f"Retrieved {len(bars)} bars")
 
-        # Access OHLCV data using Polars DataFrame
         latest_bar = bars.tail(1)
         print(f"Latest close: ${latest_bar['close'][0]:.2f}")
 
-    # Get data with specific count
-    recent_bars = await mnq_data.get_data("5min", count=20)
+    # Limit to the most recent N bars
+    recent_bars = await mnq_data.get_data("5min", bars=20)
 
-    # Get data for time range
-    from datetime import datetime, timedelta
-    end_time = datetime.now()
-    start_time = end_time - timedelta(hours=2)
-
-    range_bars = await mnq_data.get_data(
-        timeframe="1min",
-        start_time=start_time,
-        end_time=end_time
-    )
+    # Optional lock timeout (seconds). Default is data_lock_timeout (5.0).
+    recent_or_stale = await mnq_data.get_data("1min", timeout=2.0)
 
     await suite.disconnect()
 
@@ -120,14 +111,41 @@ async def volume_stats():
     # Get volume statistics
     vol_stats = await mnq_data.get_volume_stats(timeframe="1min")
     if vol_stats:
-        print(f"Total volume: {vol_stats['total_volume']:,}")
-        print(f"Average volume: {vol_stats['avg_volume']:.0f}")
-        print(f"Volume trend: {vol_stats['volume_trend']}")
+        print(f"Total volume: {vol_stats['total']:,}")
+        print(f"Average volume: {vol_stats['average']:.0f}")
+        print(f"Relative to average: {vol_stats['relative']:.1%}")
 
     await suite.disconnect()
 
 asyncio.run(volume_stats())
 ```
+
+### Session-filtered bars
+
+```python
+from project_x_py import TradingSuite, SessionConfig, SessionType
+
+async def session_bars():
+    suite = await TradingSuite.create(
+        ["MNQ"],
+        timeframes=["1min", "5min"],
+        session_config=SessionConfig(session_type=SessionType.RTH),
+    )
+    mnq = suite["MNQ"].data
+
+    # Bounded: copies under the read lock (default 2s), then filters.
+    # On timeout returns the last successful snapshot, or None.
+    rth = await mnq.get_session_data("1min", SessionType.RTH)
+    eth = await mnq.get_session_data("1min", SessionType.ETH, timeout=1.0)
+
+    await suite.disconnect()
+
+asyncio.run(session_bars())
+```
+
+`get_session_data()` will not hold the bar-cache lock while filtering, and it
+will not wait forever if a writer is stuck. Configure the defaults with
+`data_lock_timeout` and `session_data_timeout` on `DataManagerConfig`.
 
 ## Memory Management
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The canonical changelog is the repository root [CHANGELOG.md](https://github.com/TexasCoding/project-x-py/blob/main/CHANGELOG.md). This page is a docs-site copy.
 
+## [4.2.1] - 2026-09-03
+
+`get_session_data()` no longer hangs when the bar cache is locked. Reads
+time out (default 2s) and return the last snapshot when one exists (#137).
+See the root CHANGELOG for the full list.
+
 ## [4.2.0] - 2026-08-31
 
 `get_bars()` pages the 20,000-bar Gateway cap and stitches expired months

--- a/docs/guide/sessions.md
+++ b/docs/guide/sessions.md
@@ -7,9 +7,9 @@
 
 The Trading Sessions module enables you to filter and analyze market data based on different trading sessions:
 
-- **RTH (Regular Trading Hours)**: Traditional market hours (typically 9:30 AM - 4:00 PM ET for equities)
-- **ETH (Electronic Trading Hours)**: Extended/overnight trading hours
-- **BOTH**: All available trading hours (default behavior)
+- **RTH (Regular Trading Hours)**: Pit hours (typically 9:30 AM - 4:00 PM ET for equity index futures)
+- **ETH (Electronic Trading Hours)**: All hours except the daily maintenance break
+- **CUSTOM**: Caller-supplied `SessionTimes`
 
 This feature is particularly useful for:
 - Separating overnight volatility from regular session price action
@@ -36,7 +36,7 @@ session_filter = SessionFilterMixin()
 rth_data = await session_filter.filter_by_session(
     data,
     SessionType.RTH,
-    "ES"
+    "ES",
 )
 
 eth_data = await session_filter.filter_by_session(
@@ -53,9 +53,9 @@ eth_data = await session_filter.filter_by_session(
 ```python
 from project_x_py.sessions import SessionType
 
-SessionType.RTH   # Regular Trading Hours only
-SessionType.ETH   # Electronic Trading Hours only
-SessionType.BOTH  # All trading hours (default)
+SessionType.RTH     # Regular Trading Hours only
+SessionType.ETH     # Electronic Trading Hours (excludes maintenance)
+SessionType.CUSTOM  # Caller-supplied SessionTimes
 ```
 
 ### Product-Specific Sessions
@@ -281,6 +281,27 @@ filtered_data = await filter_mixin.filter_by_session(
     custom_session_times=custom_times  # Optional
 )
 ```
+
+## Live `get_session_data` (v4.2.1+)
+
+Call this from `on_bar`. It copies bars under a **bounded** read lock
+(default 2 seconds), then filters after the lock is released:
+
+```python
+from project_x_py.sessions import SessionType
+
+rth = await suite["MNQ"].data.get_session_data("1min", SessionType.RTH)
+# optional: timeout=1.0
+```
+
+If the bar cache is mid-update and the lock does not release in time, the
+call returns the last successful snapshot (or `None` on the first attempt)
+instead of hanging. Configure defaults with `session_data_timeout` and
+`data_lock_timeout` on the data-manager config.
+
+`session_type` may be omitted; it then uses `session_config.session_type`.
+Gateway contract ids (`CON.F.US.MNQ.H26`) resolve to the product calendar
+via `resolve_session_product()`.
 
 ## Performance Considerations
 
@@ -524,7 +545,7 @@ logging.getLogger("project_x_py.sessions").setLevel(logging.DEBUG)
 
 - `SessionConfig`: Configuration for session types and times
 - `SessionTimes`: Definition of session start/end times
-- `SessionType`: Enum for RTH, ETH, BOTH
+- `SessionType`: Enum for RTH, ETH, CUSTOM
 - `SessionFilterMixin`: Main filtering functionality
 - `SessionStatistics`: Statistical calculations by session
 - `SessionAnalytics`: Advanced analytics and comparisons

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@
 
 **project-x-py** is a high-performance **async Python SDK** for the [ProjectX Trading Platform](https://www.projectx.com/) Gateway API. This library enables developers to build sophisticated trading strategies and applications by providing comprehensive async access to futures trading operations, real-time market data, Level 2 orderbook analysis, and 64 named indicators (Polars implementations; **not** a full TA-Lib port).
 
-!!! note "Version 4.2.0"
-    **Latest Release**: TopstepX-only Gateway SDK (`api.topstepx.com` / `rtc.topstepx.com`) with native brackets, risk OCO and entry-order gating, stale-feed watchdog, `OrderSubmissionUncertainError`, and 64 named Polars indicators (not a full TA-Lib port). v4.2.0 pages `get_bars()` at the 20,000-bar cap, stitches expired months on hourly+ product-root requests, and stops `suite.get_stats()` from re-entering itself (#133, #134). Sub-hour history remains the active contract only. See the [v3 → v4 migration guide](migration/v3-to-v4.md).
+!!! note "Version 4.2.1"
+    **Latest Release**: TopstepX-only Gateway SDK (`api.topstepx.com` / `rtc.topstepx.com`) with native brackets, risk OCO and entry-order gating, stale-feed watchdog, `OrderSubmissionUncertainError`, and 64 named Polars indicators (not a full TA-Lib port). v4.2.1 stops `get_session_data()` from hanging on the bar-cache lock (#137). v4.2.0 pages `get_bars()` at the 20,000-bar cap and stitches expired months on hourly+ product-root requests. Sub-hour history remains the active contract only. See the [v3 → v4 migration guide](migration/v3-to-v4.md).
 
 !!! note "Stable Production Release"
     This project maintains strict semantic versioning. v4.0.0 is a major release with documented breaking changes. Deprecation warnings are provided for at least 2 minor versions before removal.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
-# ProjectX Python SDK Examples (v4.2.0)
+# ProjectX Python SDK Examples (v4.2.1)
 
-This directory contains working examples for the ProjectX Python SDK v4.2.0. All examples use **MNQ (Micro E-mini NASDAQ)** contracts to minimize risk during testing.
+This directory contains working examples for the ProjectX Python SDK v4.2.1. All examples use **MNQ (Micro E-mini NASDAQ)** contracts to minimize risk during testing.
 
 **Note:** v4.0 is the TopstepX Gateway revival. Use `TradingSuite.create()`, `await suite.get_stats()` / `export_stats()`, and see `docs/migration/v3-to-v4.md` for breaking changes.
 

--- a/examples/sessions/README.md
+++ b/examples/sessions/README.md
@@ -41,8 +41,8 @@ suite = await TradingSuite.create(
     session_config=session_config
 )
 
-# Option 3: Default (BOTH - all trading hours)
-suite = await TradingSuite.create("MNQ")  # Uses BOTH by default
+# Option 3: Default (ETH — all hours except the maintenance break)
+suite = await TradingSuite.create("MNQ")  # SessionType.ETH by default
 ```
 
 ### Immediate Usage
@@ -72,9 +72,9 @@ if stats:
 ```python
 from project_x_py.sessions import SessionType
 
-SessionType.RTH   # Regular Trading Hours only
-SessionType.ETH   # Electronic Trading Hours only
-SessionType.BOTH  # All trading hours (default)
+SessionType.RTH     # Regular Trading Hours only
+SessionType.ETH     # Electronic Trading Hours (excludes maintenance)
+SessionType.CUSTOM  # Caller-supplied SessionTimes
 ```
 
 ### SessionConfig Options
@@ -84,7 +84,7 @@ from datetime import time
 
 # Basic configuration
 config = SessionConfig(
-    session_type=SessionType.RTH  # RTH, ETH, or BOTH
+    session_type=SessionType.RTH  # RTH, ETH, or CUSTOM
 )
 
 # Custom session times
@@ -773,7 +773,7 @@ elif stats.get('rth_volume', 0) == 0:
 ```python
 # Problem: Using all data instead of session-filtered
 mnq_context = suite["MNQ"]
-full_data = await mnq_context.data.get_data("5min")  # Contains BOTH sessions
+full_data = await mnq_context.data.get_data("5min")  # Unfiltered cache (RTH + ETH)
 
 if full_data is not None:
     wrong_sma = full_data.pipe(SMA, period=20)  # Uses all data
@@ -900,7 +900,7 @@ All existing code continues to work without changes. The session system is addit
 
 ```python
 # This still works exactly as before
-suite = await TradingSuite.create("MNQ")  # Uses BOTH (all hours) by default
+suite = await TradingSuite.create("MNQ")  # ETH by default (all hours except maintenance)
 mnq_context = suite["MNQ"]
 data = await mnq_context.data.get_data("5min")  # Returns all data
 

--- a/src/project_x_py/__init__.py
+++ b/src/project_x_py/__init__.py
@@ -3,7 +3,7 @@ ProjectX Python SDK for Trading Applications
 
 Author: @TexasCoding
 Date: 2026-08-29
-Version: 4.2.0 - Stats re-entry fix, paged/stitched historical bars (#133, #134)
+Version: 4.2.1 - get_session_data no longer hangs on bar-cache lock (#137)
 
 Overview:
     A comprehensive Python SDK for the ProjectX Trading Platform Gateway API, providing
@@ -96,7 +96,7 @@ Architecture Benefits:
 It provides the infrastructure to help developers create their own trading applications
 that integrate with the ProjectX platform.
 
-Version: 4.2.0
+Version: 4.2.1
 Author: TexasCoding
 
 See Also:
@@ -109,7 +109,7 @@ See Also:
     - `utils`: Utility functions and calculations
 """
 
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 __author__ = "TexasCoding"
 
 # Core client classes - renamed from Async* to standard names
@@ -207,6 +207,7 @@ from project_x_py.sessions import (
     SessionStatistics,
     SessionTimes,
     SessionType,
+    resolve_session_product,
 )
 from project_x_py.trading_suite import Features, TradingSuite, TradingSuiteConfig
 
@@ -252,6 +253,7 @@ __all__ = [
     "SessionTimes",
     "SessionType",
     "DEFAULT_SESSIONS",
+    "resolve_session_product",
     "SessionFilterMixin",
     "SessionStatistics",
     "SessionAnalytics",

--- a/src/project_x_py/client/http.py
+++ b/src/project_x_py/client/http.py
@@ -158,7 +158,7 @@ class HttpMixin:
             verify=True,
             follow_redirects=False,
             headers={
-                "User-Agent": "ProjectX-Python-SDK/4.2.0",
+                "User-Agent": "ProjectX-Python-SDK/4.2.1",
                 "Accept": "application/json",
             },
         )

--- a/src/project_x_py/indicators/__init__.py
+++ b/src/project_x_py/indicators/__init__.py
@@ -206,7 +206,7 @@ from .candlestick import (
 )
 
 # Version info
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 __author__ = "TexasCoding"
 
 

--- a/src/project_x_py/realtime_data_manager/core.py
+++ b/src/project_x_py/realtime_data_manager/core.py
@@ -423,6 +423,8 @@ class RealtimeDataManager(
 
         # Initialize data storage
         self.data: dict[str, pl.DataFrame] = {}
+        self._last_data_snapshot: dict[str, pl.DataFrame] = {}
+        self._last_session_snapshot: dict[tuple[str, str], pl.DataFrame] = {}
 
         # Apply defaults which sets max_bars_per_timeframe etc.
         self._apply_config_defaults()
@@ -735,6 +737,9 @@ class RealtimeDataManager(
         self.cleanup_interval_minutes = self.config.get("cleanup_interval_minutes", 5)
         self.historical_data_cache = self.config.get("historical_data_cache", True)
         self.cache_expiry_hours = self.config.get("cache_expiry_hours", 24)
+        # Bounded lock waits so get_data / get_session_data cannot hang (#137)
+        self.data_lock_timeout = float(self.config.get("data_lock_timeout", 5.0))
+        self.session_data_timeout = float(self.config.get("session_data_timeout", 2.0))
 
         # Configuration for historical data loading
         self.default_initial_days = self.config.get("initial_days", 1)

--- a/src/project_x_py/realtime_data_manager/data_access.py
+++ b/src/project_x_py/realtime_data_manager/data_access.py
@@ -102,6 +102,8 @@ import asyncio
 import logging
 import time
 from collections import deque
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -130,11 +132,75 @@ class DataAccessMixin:
         instrument: str
         session_filter: Any
         session_config: Any
+        data_lock_timeout: float
+        session_data_timeout: float
+        _last_data_snapshot: dict[str, pl.DataFrame]
+        _last_session_snapshot: dict[tuple[str, str], pl.DataFrame]
+
+    def _lock_timeout(
+        self, timeout: float | None, default_attr: str, fallback: float
+    ) -> float:
+        if timeout is not None:
+            return timeout
+        return float(getattr(self, default_attr, fallback))
+
+    @asynccontextmanager
+    async def _data_read(self, timeout: float | None = None) -> AsyncIterator[None]:
+        """Acquire the data read lock, falling back to a regular lock."""
+        from project_x_py.utils.lock_optimization import AsyncRWLock
+
+        rw = getattr(self, "data_rw_lock", None)
+        if isinstance(rw, AsyncRWLock):
+            async with rw.read_lock(timeout):
+                yield
+            return
+
+        lock = getattr(self, "data_lock", None)
+        if lock is None:
+            yield
+            return
+
+        if timeout is not None:
+            async with asyncio.timeout(timeout):
+                async with lock:
+                    yield
+            return
+
+        async with lock:
+            yield
+
+    def _slice_copied_frame(
+        self, timeframe: str, bars: int | None
+    ) -> pl.DataFrame | None:
+        if timeframe not in self.data:
+            return None
+        df = self.data[timeframe]
+        if not isinstance(df, pl.DataFrame):
+            return df
+        if bars is not None and len(df) > bars:
+            df = df.tail(bars)
+        return df.clone()
+
+    def _store_data_snapshot(self, timeframe: str, df: pl.DataFrame) -> None:
+        snapshots = getattr(self, "_last_data_snapshot", None)
+        if snapshots is None:
+            self._last_data_snapshot = {}
+            snapshots = self._last_data_snapshot
+        snapshots[timeframe] = df
+
+    def _store_session_snapshot(self, key: tuple[str, str], df: pl.DataFrame) -> None:
+        snapshots = getattr(self, "_last_session_snapshot", None)
+        if snapshots is None:
+            self._last_session_snapshot = {}
+            snapshots = self._last_session_snapshot
+        snapshots[key] = df
 
     async def get_data(
         self,
         timeframe: str = "5min",
         bars: int | None = None,
+        *,
+        timeout: float | None = None,
     ) -> pl.DataFrame | None:
         """
         Get OHLCV data for a specific timeframe.
@@ -197,34 +263,34 @@ class DataAccessMixin:
             - This method is thread-safe and can be called concurrently from multiple tasks
             - The returned DataFrame is a copy of the internal data and can be modified safely
             - For memory efficiency, specify the 'bars' parameter to limit the result size
+            - Lock acquisition is bounded (default 5s). On timeout the last successful
+              copy is returned when available, otherwise None.
         """
-        # Check for optimized read lock (AsyncRWLock) and use it for better parallelism
-        if hasattr(self, "data_rw_lock"):
-            try:
-                from project_x_py.utils.lock_optimization import AsyncRWLock
-
-                if isinstance(self.data_rw_lock, AsyncRWLock):
-                    async with self.data_rw_lock.read_lock():
-                        if timeframe not in self.data:
-                            return None
-
-                        df = self.data[timeframe]
-                        if bars is not None and len(df) > bars:
-                            return df.tail(bars)
-                        return df
-            except (ImportError, TypeError):
-                # Fall back to regular lock if AsyncRWLock not available or type check fails
-                pass
-
-        # Fallback to regular data_lock for backward compatibility
-        async with self.data_lock:  # type: ignore
-            if timeframe not in self.data:
+        lock_timeout = self._lock_timeout(timeout, "data_lock_timeout", 5.0)
+        try:
+            async with self._data_read(lock_timeout):
+                df = self._slice_copied_frame(timeframe, bars)
+        except TimeoutError:
+            logger.warning(
+                "get_data timed out after %.3ss waiting for %s (%s)",
+                lock_timeout,
+                timeframe,
+                getattr(self, "instrument", "?"),
+            )
+            snapshots = getattr(self, "_last_data_snapshot", {})
+            cached = snapshots.get(timeframe)
+            if cached is None:
                 return None
+            if bars is not None and len(cached) > bars:
+                return cached.tail(bars)
+            return cached
+        except (ImportError, TypeError):
+            async with self.data_lock:  # type: ignore[union-attr]
+                df = self._slice_copied_frame(timeframe, bars)
 
-            df = self.data[timeframe]
-            if bars is not None and len(df) > bars:
-                return df.tail(bars)
-            return df
+        if df is not None:
+            self._store_data_snapshot(timeframe, df)
+        return df
 
     async def get_current_price(self) -> float | None:
         """
@@ -312,18 +378,16 @@ class DataAccessMixin:
                     return float(frame["close"][-1])
             return None
 
-        if hasattr(self, "data_rw_lock"):
-            try:
-                from project_x_py.utils.lock_optimization import AsyncRWLock
-
-                if isinstance(self.data_rw_lock, AsyncRWLock):
-                    async with self.data_rw_lock.read_lock():
-                        return _read_close()
-            except (ImportError, TypeError):
-                pass
-
-        async with self.data_lock:  # type: ignore
-            return _read_close()
+        lock_timeout = self._lock_timeout(None, "data_lock_timeout", 5.0)
+        try:
+            async with self._data_read(lock_timeout):
+                return _read_close()
+        except TimeoutError:
+            logger.warning("Timed out copying latest bar close")
+            return None
+        except (ImportError, TypeError):
+            async with self.data_lock:  # type: ignore[union-attr]
+                return _read_close()
 
     async def _get_rest_fallback_price(self) -> float | None:
         """Use REST partial bars when the realtime tick feed is stale or empty."""
@@ -353,21 +417,16 @@ class DataAccessMixin:
             >>> for tf, data in mtf_data.items():
             ...     print(f"{tf}: {len(data)} bars")
         """
-        # Use optimized read lock if available
-        if hasattr(self, "data_rw_lock"):
-            try:
-                from project_x_py.utils.lock_optimization import AsyncRWLock
-
-                if isinstance(self.data_rw_lock, AsyncRWLock):
-                    async with self.data_rw_lock.read_lock():
-                        return {tf: df.clone() for tf, df in self.data.items()}
-            except (ImportError, TypeError):
-                # Fall back to regular lock if AsyncRWLock not available or type check fails
-                pass
-
-        # Fallback to regular lock
-        async with self.data_lock:  # type: ignore
-            return {tf: df.clone() for tf, df in self.data.items()}
+        lock_timeout = self._lock_timeout(None, "data_lock_timeout", 5.0)
+        try:
+            async with self._data_read(lock_timeout):
+                return {tf: df.clone() for tf, df in self.data.items()}
+        except TimeoutError:
+            logger.warning("get_mtf_data timed out after %.3ss", lock_timeout)
+            return {}
+        except (ImportError, TypeError):
+            async with self.data_lock:  # type: ignore[union-attr]
+                return {tf: df.clone() for tf, df in self.data.items()}
 
     async def get_latest_bars(
         self,
@@ -577,18 +636,14 @@ class DataAccessMixin:
             ...     # Safe to start trading logic
             ...     strategy.start()
         """
-        # Handle both Lock and AsyncRWLock types
+        lock_timeout = self._lock_timeout(None, "data_lock_timeout", 5.0)
         try:
-            from project_x_py.utils.lock_optimization import AsyncRWLock
-
-            if isinstance(self.data_lock, AsyncRWLock):
-                async with self.data_lock.read_lock():
-                    return await self._check_data_readiness(timeframe, min_bars)
-            else:
-                async with self.data_lock:
-                    return await self._check_data_readiness(timeframe, min_bars)
+            async with self._data_read(lock_timeout):
+                return await self._check_data_readiness(timeframe, min_bars)
+        except TimeoutError:
+            logger.warning("is_data_ready timed out after %.3ss", lock_timeout)
+            return False
         except (ImportError, TypeError):
-            # Fall back to regular lock if AsyncRWLock not available or type check fails
             async with self.data_lock:  # type: ignore[union-attr]
                 return await self._check_data_readiness(timeframe, min_bars)
 
@@ -679,14 +734,25 @@ class DataAccessMixin:
         return data
 
     async def get_session_data(
-        self, timeframe: str, session_type: Any
+        self,
+        timeframe: str,
+        session_type: Any = None,
+        *,
+        timeout: float | None = None,
     ) -> pl.DataFrame | None:
         """
         Get data filtered by specific trading session (RTH/ETH).
 
+        Copies bars under a bounded read lock, then filters after releasing
+        the lock so ``on_bar`` cannot stall behind a writer. On lock timeout
+        the last successful session snapshot is returned when one exists.
+
         Args:
             timeframe: Timeframe to retrieve data for (e.g., "1min", "5min")
-            session_type: SessionType enum value (RTH, ETH, or CUSTOM)
+            session_type: SessionType enum value (RTH, ETH, or CUSTOM).
+                Defaults to ``session_config.session_type`` when set, else ETH.
+            timeout: Seconds to wait for the data lock and filter. Defaults to
+                ``session_data_timeout`` (2.0s). Does not block forever.
 
         Returns:
             DataFrame containing only data from the specified session, or None if no data
@@ -700,28 +766,55 @@ class DataAccessMixin:
             eth_data = await manager.get_session_data("5min", SessionType.ETH)
             ```
         """
-        # Get all data for the timeframe
-        data = await self.get_data(timeframe)
-        if data is None or data.is_empty():
-            return None
-
-        # Apply session filtering if we have a session filter
-        if hasattr(self, "session_filter") and self.session_filter is not None:
-            from project_x_py.sessions import SessionType
-
-            filtered = await self.session_filter.filter_by_session(
-                data, session_type, self.instrument
-            )
-            return filtered if not filtered.is_empty() else None
-
-        # If no session filter configured, return all data for ETH, none for RTH
         from project_x_py.sessions import SessionType
+        from project_x_py.sessions.config import resolve_session_product
 
-        if session_type == SessionType.ETH:
-            return data
-        else:
-            # Without a filter, we can't determine RTH hours
+        lock_timeout = self._lock_timeout(timeout, "session_data_timeout", 2.0)
+        if session_type is None:
+            session_config = getattr(self, "session_config", None)
+            session_type = (
+                session_config.session_type
+                if session_config is not None
+                else SessionType.ETH
+            )
+        cache_key = (timeframe, str(session_type))
+
+        async def _load() -> pl.DataFrame | None:
+            data = await self.get_data(timeframe, timeout=lock_timeout)
+            if data is None or data.is_empty():
+                return None
+
+            if hasattr(self, "session_filter") and self.session_filter is not None:
+                product = resolve_session_product(str(self.instrument))
+                try:
+                    filtered = await self.session_filter.filter_by_session(
+                        data, session_type, product
+                    )
+                except ValueError as e:
+                    logger.warning("get_session_data filter failed: %s", e)
+                    return None
+                return filtered if not filtered.is_empty() else None
+
+            if session_type == SessionType.ETH:
+                return data
             return None
+
+        try:
+            async with asyncio.timeout(lock_timeout):
+                result = await _load()
+        except TimeoutError:
+            logger.warning(
+                "get_session_data timed out after %.3ss (%s %s)",
+                lock_timeout,
+                getattr(self, "instrument", "?"),
+                timeframe,
+            )
+            snapshots = getattr(self, "_last_session_snapshot", {})
+            return snapshots.get(cache_key)
+
+        if result is not None:
+            self._store_session_snapshot(cache_key, result)
+        return result
 
     async def get_session_statistics(self, timeframe: str) -> dict[str, Any]:
         """

--- a/src/project_x_py/realtime_data_manager/memory_management.py
+++ b/src/project_x_py/realtime_data_manager/memory_management.py
@@ -255,7 +255,8 @@ class MemoryManagementMixin(TaskManagerMixin):
             f"Buffer overflow detected for {timeframe}: {utilization:.1f}% utilization"
         )
 
-        # Trigger overflow alerts
+        # Trigger overflow alerts. Callbacks run on this task, so a nested
+        # data write_lock is re-entrant; get_data uses a bounded read timeout.
         for callback in self._overflow_alert_callbacks:
             try:
                 if asyncio.iscoroutinefunction(callback):
@@ -403,7 +404,6 @@ class MemoryManagementMixin(TaskManagerMixin):
         # Import here to avoid circular dependency
         from project_x_py.utils.lock_optimization import AsyncRWLock
 
-        # Use appropriate lock method based on lock type
         if isinstance(self.data_lock, AsyncRWLock):
             async with self.data_lock.write_lock():
                 await self._perform_cleanup()

--- a/src/project_x_py/sessions/__init__.py
+++ b/src/project_x_py/sessions/__init__.py
@@ -8,7 +8,13 @@ Author: TDD Implementation
 Date: 2025-08-28
 """
 
-from .config import DEFAULT_SESSIONS, SessionConfig, SessionTimes, SessionType
+from .config import (
+    DEFAULT_SESSIONS,
+    SessionConfig,
+    SessionTimes,
+    SessionType,
+    resolve_session_product,
+)
 from .filtering import SessionFilterMixin
 from .indicators import (
     aggregate_with_sessions,
@@ -28,6 +34,7 @@ __all__ = [
     "SessionTimes",
     "SessionType",
     "DEFAULT_SESSIONS",
+    "resolve_session_product",
     # Filtering
     "SessionFilterMixin",
     # Statistics

--- a/src/project_x_py/sessions/config.py
+++ b/src/project_x_py/sessions/config.py
@@ -189,6 +189,39 @@ class SessionConfig:
 
 
 # Default session times for major futures products
+def resolve_session_product(product: str) -> str:
+    """Map a contract id or listed symbol to a DEFAULT_SESSIONS key.
+
+    Accepts root symbols (``MNQ``), Gateway ids (``CON.F.US.MNQ.H26``),
+    and month-coded names (``MNQH26``). Returns the original string when
+    no known product is found so callers can still raise ``Unknown product``.
+    """
+    if product in DEFAULT_SESSIONS:
+        return product
+    upper = product.upper()
+    if upper in DEFAULT_SESSIONS:
+        return upper
+
+    tokens = product.replace("-", ".").split(".")
+    candidates: list[str] = []
+    for token in reversed(tokens):
+        letters = "".join(ch for ch in token if ch.isalpha()).upper()
+        if letters:
+            candidates.append(letters)
+    if not candidates:
+        letters = "".join(ch for ch in product if ch.isalpha()).upper()
+        if letters:
+            candidates.append(letters)
+
+    for letters in candidates:
+        if letters in DEFAULT_SESSIONS:
+            return letters
+        for length in (4, 3, 2):
+            if len(letters) >= length and letters[:length] in DEFAULT_SESSIONS:
+                return letters[:length]
+    return product
+
+
 DEFAULT_SESSIONS: dict[str, SessionTimes] = {
     # ========== EQUITY INDEX FUTURES ==========
     # Full-size Equity Index - RTH: 9:30 AM - 4:00 PM ET

--- a/src/project_x_py/sessions/filtering.py
+++ b/src/project_x_py/sessions/filtering.py
@@ -14,7 +14,13 @@ from typing import Any
 import polars as pl
 import pytz
 
-from .config import DEFAULT_SESSIONS, SessionConfig, SessionTimes, SessionType
+from .config import (
+    DEFAULT_SESSIONS,
+    SessionConfig,
+    SessionTimes,
+    SessionType,
+    resolve_session_product,
+)
 
 # For broader compatibility, we'll catch ValueError and re-raise with our message
 
@@ -175,8 +181,9 @@ class SessionFilterMixin:
         if custom_session_times:
             return custom_session_times
 
-        if product in DEFAULT_SESSIONS:
-            return DEFAULT_SESSIONS[product]
+        resolved = resolve_session_product(product)
+        if resolved in DEFAULT_SESSIONS:
+            return DEFAULT_SESSIONS[resolved]
 
         raise ValueError(f"Unknown product: {product}")
 
@@ -334,9 +341,10 @@ class SessionFilterMixin:
 
     def _get_session_times_for_product(self, product: str) -> SessionTimes:
         """Get session times for the specified product."""
-        if product not in DEFAULT_SESSIONS:
+        resolved = resolve_session_product(product)
+        if resolved not in DEFAULT_SESSIONS:
             raise ValueError(f"Unknown product: {product}")
-        return DEFAULT_SESSIONS[product]
+        return DEFAULT_SESSIONS[resolved]
 
     def _convert_to_market_time(self, timestamp: datetime | str) -> datetime:
         """Convert timestamp to market timezone (ET)."""

--- a/src/project_x_py/statistics/__init__.py
+++ b/src/project_x_py/statistics/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
     "CleanupScheduler",
 ]
 
-__version__ = "4.2.0"
+__version__ = "4.2.1"

--- a/src/project_x_py/trading_suite.py
+++ b/src/project_x_py/trading_suite.py
@@ -248,6 +248,8 @@ class TradingSuiteConfig:
             "enable_level2_data": Features.ORDERBOOK in self.features,
             "data_validation": True,
             "auto_cleanup": True,
+            "data_lock_timeout": 5.0,
+            "session_data_timeout": 2.0,
             "enable_dynamic_limits": True,  # Enable dynamic resource limits by default
             "resource_config": {
                 "memory_target_percent": 15.0,  # Use 15% of available memory
@@ -1429,7 +1431,11 @@ class TradingSuite:
                 )
 
     async def get_session_data(
-        self, timeframe: str, session_type: SessionType | None = None
+        self,
+        timeframe: str,
+        session_type: SessionType | None = None,
+        *,
+        timeout: float | None = None,
     ) -> Any:
         """
         Get session-filtered market data.
@@ -1437,6 +1443,7 @@ class TradingSuite:
         Args:
             timeframe: Data timeframe (e.g., "1min", "5min")
             session_type: Optional session type override
+            timeout: Seconds to wait for the bar-cache lock (default 2.0)
 
         Returns:
             Polars DataFrame with session-filtered data
@@ -1447,11 +1454,15 @@ class TradingSuite:
             rth_data = await suite.get_session_data("1min", SessionType.RTH)
             ```
         """
+        timeout_kw: dict[str, float] = {}
+        if timeout is not None:
+            timeout_kw["timeout"] = timeout
+
         # Handle single instrument mode (backward compatibility)
         if self._is_single_instrument and self._single_context:
             if hasattr(self._single_context.data, "get_session_data"):
                 return await self._single_context.data.get_session_data(
-                    timeframe, session_type
+                    timeframe, session_type, **timeout_kw
                 )
             # Fallback to regular data if no session support
             return await self._single_context.data.get_data(timeframe)
@@ -1461,7 +1472,7 @@ class TradingSuite:
         for symbol, context in self._instruments.items():
             if hasattr(context.data, "get_session_data"):
                 result[symbol] = await context.data.get_session_data(
-                    timeframe, session_type
+                    timeframe, session_type, **timeout_kw
                 )
             else:
                 result[symbol] = await context.data.get_data(timeframe)

--- a/src/project_x_py/types/config_types.py
+++ b/src/project_x_py/types/config_types.py
@@ -170,6 +170,8 @@ class DataManagerConfig(TypedDict):
     cache_expiry_hours: NotRequired[int]
     timezone: NotRequired[str]  # Timezone for timestamp handling
     initial_days: NotRequired[int]  # Initial days of historical data to load
+    data_lock_timeout: NotRequired[float]  # Seconds to wait for bar-cache read lock
+    session_data_timeout: NotRequired[float]  # Seconds for get_session_data (#137)
 
     # Dynamic resource management
     enable_dynamic_limits: NotRequired[bool]

--- a/src/project_x_py/utils/lock_optimization.py
+++ b/src/project_x_py/utils/lock_optimization.py
@@ -17,6 +17,7 @@ Key Features:
     - Fine-grained locking strategies for reduced contention
     - Lock profiling and contention monitoring utilities
     - Timeout-based lock acquisition with deadlock prevention
+    - Writer preference so a waiting writer is not starved by new readers
     - Memory-efficient lock tracking and cleanup
 
 Performance Benefits:
@@ -24,7 +25,7 @@ Performance Benefits:
     - Improved parallelism for DataFrame read access
     - Sub-millisecond lock acquisition times
     - Lock-free updates for high-frequency data (10K+ ops/sec)
-    - Deadlock prevention through ordered lock acquisition
+    - Deadlock prevention through ordered lock acquisition and timeouts
 
 Components:
     - AsyncRWLock: High-performance read/write lock
@@ -77,7 +78,7 @@ Architecture Patterns:
     - Fine-grained locking: Per-resource locks instead of global locks
     - Lock ordering: Consistent acquisition order prevents deadlocks
     - Timeout-based acquisition: Prevents indefinite blocking
-    - Reader preference: Optimized for read-heavy workloads
+    - Writer preference: Waiting writers block new readers to avoid livelock
     - Lock-free fast paths: High-frequency operations bypass locks
 
 See Also:
@@ -121,33 +122,89 @@ class AsyncRWLock:
     """
     High-performance async read/write lock optimized for DataFrame operations.
 
-    Provides reader preference for read-heavy workloads common in financial data
-    processing. Multiple readers can acquire the lock concurrently, but writers
-    get exclusive access. Includes timeout support and contention monitoring.
+    Multiple readers can hold the lock concurrently. Writers get exclusive
+    access. Waiting writers block new readers (writer preference) so a
+    writer cannot be starved by a continuous stream of readers. Acquisition
+    is cancellable and supports timeouts.
 
     Key Features:
         - Multiple concurrent readers with single exclusive writer
-        - Reader preference for read-heavy workloads
+        - Writer preference to prevent reader livelock
         - Timeout support to prevent deadlocks
+        - Reentrant write lock for the owning task
         - Contention monitoring and statistics
-        - Memory-efficient implementation with weak references
-        - Deadlock prevention through ordered acquisition
-
-    Performance Characteristics:
-        - Read operations: O(1) acquisition time
-        - Write operations: Waits for all readers to complete
-        - Memory usage: ~100 bytes per lock instance
-        - Concurrent readers: Limited only by system resources
     """
 
     def __init__(self, name: str = "unnamed"):
         self.name = name
+        self._cond = asyncio.Condition()
         self._readers: WeakSet[asyncio.Task[Any]] = WeakSet()
-        self._writer_lock = asyncio.Lock()
         self._reader_count = 0
-        self._reader_count_lock = asyncio.Lock()
+        self._writer = False
+        self._writer_task: asyncio.Task[Any] | None = None
+        self._writer_depth = 0
+        self._waiting_writers = 0
         self._stats = LockStats()
         self._creation_time = time.time()
+
+    def _record_acquisition(self, start_time: float) -> None:
+        wait_time = (time.time() - start_time) * 1000
+        self._stats.total_acquisitions += 1
+        self._stats.total_wait_time_ms += wait_time
+        self._stats.max_wait_time_ms = max(self._stats.max_wait_time_ms, wait_time)
+        self._stats.min_wait_time_ms = min(self._stats.min_wait_time_ms, wait_time)
+        self._stats.last_acquisition = start_time
+        if wait_time > 1.0:
+            self._stats.contentions += 1
+
+    async def _acquire_read(self) -> None:
+        async with self._cond:
+            while self._writer or self._waiting_writers > 0:
+                await self._cond.wait()
+            self._reader_count += 1
+            current_task = asyncio.current_task()
+            if current_task:
+                self._readers.add(current_task)
+            self._stats.concurrent_readers = self._reader_count
+            self._stats.max_concurrent_readers = max(
+                self._stats.max_concurrent_readers, self._reader_count
+            )
+
+    async def _release_read(self) -> None:
+        async with self._cond:
+            self._reader_count = max(0, self._reader_count - 1)
+            current_task = asyncio.current_task()
+            if current_task and current_task in self._readers:
+                self._readers.discard(current_task)
+            self._stats.concurrent_readers = self._reader_count
+            if self._reader_count == 0:
+                self._cond.notify_all()
+
+    async def _acquire_write(self) -> None:
+        async with self._cond:
+            current = asyncio.current_task()
+            if self._writer and self._writer_task is current:
+                self._writer_depth += 1
+                return
+            self._waiting_writers += 1
+            try:
+                while self._writer or self._reader_count > 0:
+                    await self._cond.wait()
+                self._writer = True
+                self._writer_task = current
+                self._writer_depth = 1
+            finally:
+                self._waiting_writers -= 1
+
+    async def _release_write(self) -> None:
+        async with self._cond:
+            self._writer_depth -= 1
+            if self._writer_depth > 0:
+                return
+            self._writer = False
+            self._writer_task = None
+            self._writer_depth = 0
+            self._cond.notify_all()
 
     @asynccontextmanager
     async def read_lock(
@@ -157,7 +214,7 @@ class AsyncRWLock:
         Acquire read lock with optional timeout.
 
         Multiple readers can hold the lock simultaneously. Blocks if a writer
-        is waiting or has acquired the lock.
+        is active or waiting.
 
         Args:
             timeout: Maximum time to wait for lock acquisition (None = no timeout)
@@ -167,55 +224,18 @@ class AsyncRWLock:
 
         Raises:
             asyncio.TimeoutError: If timeout expires before acquiring lock
-
-        Example:
-            ```python
-            rw_lock = AsyncRWLock("dataframe_access")
-
-            async with rw_lock.read_lock(timeout=5.0):
-                # Multiple readers can execute this concurrently
-                data = dataframe.select(pl.col("close")).tail(100)
-                analysis = data.mean()
-            ```
         """
         start_time = time.time()
-
+        acquired = False
         try:
-            # Use timeout for reader count lock acquisition
-            if timeout:
+            if timeout is not None:
                 async with asyncio.timeout(timeout):
-                    async with self._reader_count_lock:
-                        self._reader_count += 1
-                        current_task = asyncio.current_task()
-                        if current_task:
-                            self._readers.add(current_task)
+                    await self._acquire_read()
             else:
-                async with self._reader_count_lock:
-                    self._reader_count += 1
-                    current_task = asyncio.current_task()
-                    if current_task:
-                        self._readers.add(current_task)
-
-                    # Update statistics
-                    self._stats.total_acquisitions += 1
-                    self._stats.concurrent_readers = self._reader_count
-                    self._stats.max_concurrent_readers = max(
-                        self._stats.max_concurrent_readers, self._reader_count
-                    )
-                    self._stats.last_acquisition = start_time
-
-            wait_time = (time.time() - start_time) * 1000  # Convert to ms
-
-            # Update wait time statistics
-            self._stats.total_wait_time_ms += wait_time
-            self._stats.max_wait_time_ms = max(self._stats.max_wait_time_ms, wait_time)
-            self._stats.min_wait_time_ms = min(self._stats.min_wait_time_ms, wait_time)
-
-            if wait_time > 1.0:  # Consider >1ms as contention
-                self._stats.contentions += 1
-
+                await self._acquire_read()
+            acquired = True
+            self._record_acquisition(start_time)
             yield
-
         except TimeoutError:
             self._stats.timeouts += 1
             logger.warning(
@@ -224,15 +244,11 @@ class AsyncRWLock:
             )
             raise
         finally:
-            # Always release the reader count
-            try:
-                async with self._reader_count_lock:
-                    self._reader_count = max(0, self._reader_count - 1)
-                    current_task = asyncio.current_task()
-                    if current_task and current_task in self._readers:
-                        self._readers.discard(current_task)
-            except Exception as e:
-                logger.error(f"Error releasing read lock for {self.name}: {e}")
+            if acquired:
+                try:
+                    await self._release_read()
+                except Exception as e:
+                    logger.error(f"Error releasing read lock for {self.name}: {e}")
 
     @asynccontextmanager
     async def write_lock(
@@ -243,6 +259,7 @@ class AsyncRWLock:
 
         Only one writer can hold the lock at a time, and no readers can access
         while a writer holds the lock. Waits for all existing readers to complete.
+        Re-entrant for the owning task.
 
         Args:
             timeout: Maximum time to wait for lock acquisition (None = no timeout)
@@ -252,68 +269,18 @@ class AsyncRWLock:
 
         Raises:
             asyncio.TimeoutError: If timeout expires before acquiring lock
-
-        Example:
-            ```python
-            async with rw_lock.write_lock(timeout=10.0):
-                # Exclusive access - no other readers or writers
-                dataframe = dataframe.with_columns(
-                    new_indicator=calculate_rsi(dataframe["close"])
-                )
-            ```
         """
         start_time = time.time()
-
+        acquired = False
         try:
-            # Acquire writer lock with timeout
-            if timeout:
+            if timeout is not None:
                 async with asyncio.timeout(timeout):
-                    async with self._writer_lock:
-                        # Wait for all readers to complete
-                        while self._reader_count > 0:
-                            await asyncio.sleep(0.001)  # Small delay to yield control
-
-                        wait_time = (time.time() - start_time) * 1000
-
-                        # Update statistics
-                        self._stats.total_acquisitions += 1
-                        self._stats.total_wait_time_ms += wait_time
-                        self._stats.max_wait_time_ms = max(
-                            self._stats.max_wait_time_ms, wait_time
-                        )
-                        self._stats.min_wait_time_ms = min(
-                            self._stats.min_wait_time_ms, wait_time
-                        )
-                        self._stats.last_acquisition = start_time
-
-                        if wait_time > 1.0:
-                            self._stats.contentions += 1
-
-                        yield
+                    await self._acquire_write()
             else:
-                async with self._writer_lock:
-                    # Wait for all readers to complete
-                    while self._reader_count > 0:
-                        await asyncio.sleep(0.001)  # Small delay to yield control
-
-                    wait_time = (time.time() - start_time) * 1000
-
-                    # Update statistics
-                    self._stats.total_acquisitions += 1
-                    self._stats.total_wait_time_ms += wait_time
-                    self._stats.max_wait_time_ms = max(
-                        self._stats.max_wait_time_ms, wait_time
-                    )
-                    self._stats.min_wait_time_ms = min(
-                        self._stats.min_wait_time_ms, wait_time
-                    )
-                    self._stats.last_acquisition = start_time
-
-                    if wait_time > 1.0:
-                        self._stats.contentions += 1
-
-                    yield
-
+                await self._acquire_write()
+            acquired = True
+            self._record_acquisition(start_time)
+            yield
         except TimeoutError:
             self._stats.timeouts += 1
             logger.warning(
@@ -321,6 +288,12 @@ class AsyncRWLock:
                 extra={"lock_name": self.name, "timeout": timeout},
             )
             raise
+        finally:
+            if acquired:
+                try:
+                    await self._release_write()
+                except Exception as e:
+                    logger.error(f"Error releasing write lock for {self.name}: {e}")
 
     async def get_stats(self) -> LockStats:
         """Get lock usage statistics."""

--- a/tests/realtime_data_manager/test_data_access.py
+++ b/tests/realtime_data_manager/test_data_access.py
@@ -908,9 +908,19 @@ class TestErrorHandling:
         manager = MockDataAccessManager()
         manager.data_lock = None  # Simulate missing lock
 
-        # Should handle missing lock gracefully (might use fallback or raise appropriate error)
-        with pytest.raises((AttributeError, TypeError)):
-            await manager.get_data("5min")
+        manager.data["5min"] = pl.DataFrame(
+            {
+                "timestamp": [datetime(2025, 1, 22, 9, 30, tzinfo=timezone.utc)],
+                "open": [19000.0],
+                "high": [19005.0],
+                "low": [18995.0],
+                "close": [19005.0],
+                "volume": [100],
+            }
+        )
+        result = await manager.get_data("5min")
+        assert result is not None
+        assert len(result) == 1
 
     @pytest.mark.asyncio
     async def test_handles_concurrent_modification_during_read(

--- a/tests/realtime_data_manager/test_get_session_data_hang.py
+++ b/tests/realtime_data_manager/test_get_session_data_hang.py
@@ -1,0 +1,190 @@
+"""Regression tests for get_session_data hang (#137)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from project_x_py.realtime_data_manager.data_access import DataAccessMixin
+from project_x_py.sessions import SessionFilterMixin, SessionType
+from project_x_py.utils.lock_optimization import AsyncRWLock
+
+
+def _rth_bars(n: int = 5) -> pl.DataFrame:
+    """Build a small RTH MNQ frame in UTC (14:30 UTC == 9:30 ET in January)."""
+    ny = ZoneInfo("America/New_York")
+    start = datetime(2026, 1, 5, 9, 30, tzinfo=ny)
+    rows = [start + timedelta(minutes=i) for i in range(n)]
+    return pl.DataFrame(
+        {
+            "timestamp": [t.astimezone(ZoneInfo("UTC")) for t in rows],
+            "open": [21000.0] * n,
+            "high": [21001.0] * n,
+            "low": [20999.0] * n,
+            "close": [21000.25 + i for i in range(n)],
+            "volume": [100] * n,
+        }
+    )
+
+
+class SessionDataManager(DataAccessMixin):
+    """Minimal DataAccessMixin host with a real AsyncRWLock."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, pl.DataFrame] = {}
+        self.current_tick_data: list[dict[str, object]] = []
+        self.tick_size = 0.25
+        self.timezone = ZoneInfo("UTC")
+        self.instrument = "MNQ"
+        self.session_filter = SessionFilterMixin()
+        self.session_config = None
+        self.data_rw_lock = AsyncRWLock("test-session-data")
+        self.data_lock = self.data_rw_lock
+        self.data_lock_timeout = 0.2
+        self.session_data_timeout = 0.2
+        self._last_data_snapshot: dict[str, pl.DataFrame] = {}
+        self._last_session_snapshot: dict[tuple[str, str], pl.DataFrame] = {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_session_data_times_out_when_write_lock_held() -> None:
+    manager = SessionDataManager()
+    manager.data["1min"] = _rth_bars()
+
+    async def hold_write() -> None:
+        async with manager.data_rw_lock.write_lock():
+            await asyncio.sleep(5)
+
+    holder = asyncio.create_task(hold_write())
+    await asyncio.sleep(0.03)
+    start = asyncio.get_running_loop().time()
+    result = await manager.get_session_data("1min", SessionType.RTH)
+    elapsed = asyncio.get_running_loop().time() - start
+    holder.cancel()
+    await asyncio.gather(holder, return_exceptions=True)
+
+    assert elapsed < 1.0
+    assert result is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_session_data_returns_last_known_on_timeout() -> None:
+    manager = SessionDataManager()
+    manager.data["1min"] = _rth_bars()
+    first = await manager.get_session_data("1min", SessionType.RTH)
+    assert first is not None
+    assert len(first) == 5
+
+    async def hold_write() -> None:
+        async with manager.data_rw_lock.write_lock():
+            await asyncio.sleep(5)
+
+    holder = asyncio.create_task(hold_write())
+    await asyncio.sleep(0.03)
+    stale = await manager.get_session_data("1min", SessionType.RTH)
+    holder.cancel()
+    await asyncio.gather(holder, return_exceptions=True)
+
+    assert stale is not None
+    assert stale["close"].to_list() == first["close"].to_list()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_session_data_does_not_hold_lock_during_filter() -> None:
+    manager = SessionDataManager()
+    manager.data["1min"] = _rth_bars()
+    filter_started = asyncio.Event()
+    writer_acquired = asyncio.Event()
+
+    original_filter = manager.session_filter.filter_by_session
+
+    async def slow_filter(*args: object, **kwargs: object) -> pl.DataFrame:
+        filter_started.set()
+        await writer_acquired.wait()
+        return await original_filter(*args, **kwargs)
+
+    manager.session_filter.filter_by_session = slow_filter  # type: ignore[method-assign]
+
+    async def try_write() -> None:
+        await filter_started.wait()
+        async with manager.data_rw_lock.write_lock(timeout=0.5):
+            writer_acquired.set()
+
+    result, _ = await asyncio.wait_for(
+        asyncio.gather(
+            manager.get_session_data("1min", SessionType.RTH, timeout=2.0),
+            try_write(),
+        ),
+        timeout=3.0,
+    )
+    assert result is not None
+    assert writer_acquired.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_data_returns_clone_not_live_frame() -> None:
+    manager = SessionDataManager()
+    manager.data["1min"] = _rth_bars()
+    copied = await manager.get_data("1min")
+    assert copied is not None
+    mutated = copied.with_columns(pl.col("close") * 0)
+    assert mutated["close"].to_list() != manager.data["1min"]["close"].to_list()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_session_data_defaults_session_type_from_config() -> None:
+    from project_x_py.sessions import SessionConfig
+
+    manager = SessionDataManager()
+    manager.session_config = SessionConfig(session_type=SessionType.RTH)
+    manager.session_filter = SessionFilterMixin(config=manager.session_config)
+    manager.data["1min"] = _rth_bars()
+    result = await manager.get_session_data("1min")
+    assert result is not None
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_session_data_resolves_contract_id_product() -> None:
+    manager = SessionDataManager()
+    manager.instrument = "CON.F.US.MNQ.H26"
+    manager.data["1min"] = _rth_bars()
+    result = await manager.get_session_data("1min", SessionType.RTH)
+    assert result is not None
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_session_data_cancellation_releases_lock() -> None:
+    manager = SessionDataManager()
+    manager.data["1min"] = _rth_bars()
+    manager.session_data_timeout = 5.0
+    manager.data_lock_timeout = 5.0
+
+    async def hold_write() -> None:
+        async with manager.data_rw_lock.write_lock():
+            await asyncio.sleep(5)
+
+    holder = asyncio.create_task(hold_write())
+    await asyncio.sleep(0.03)
+    reader = asyncio.create_task(manager.get_session_data("1min", SessionType.RTH))
+    await asyncio.sleep(0.03)
+    reader.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await reader
+    holder.cancel()
+    await asyncio.gather(holder, return_exceptions=True)
+    assert manager.data_rw_lock.reader_count == 0
+    async with manager.data_rw_lock.write_lock(timeout=0.2):
+        pass

--- a/tests/unit/test_session_filter.py
+++ b/tests/unit/test_session_filter.py
@@ -19,6 +19,7 @@ from project_x_py.sessions import (
     SessionFilterMixin,
     SessionTimes,
     SessionType,
+    resolve_session_product,
 )
 
 
@@ -715,6 +716,49 @@ class TestSessionFilterErrorRecovery:
 
         result = await session_filter.filter_by_session(data, SessionType.RTH, "ES")
         assert len(result) >= 0  # Should not crash
+
+
+@pytest.mark.unit
+class TestResolveSessionProduct:
+    """Map Gateway contract ids and month codes to DEFAULT_SESSIONS keys."""
+
+    def test_root_symbol_unchanged(self):
+        assert resolve_session_product("MNQ") == "MNQ"
+        assert resolve_session_product("ES") == "ES"
+
+    def test_gateway_contract_id(self):
+        assert resolve_session_product("CON.F.US.MNQ.H26") == "MNQ"
+        assert resolve_session_product("CON.F.US.MES.U26") == "MES"
+
+    def test_month_coded_symbol(self):
+        assert resolve_session_product("MNQH26") == "MNQ"
+        assert resolve_session_product("MESH26") == "MES"
+
+    @pytest.mark.asyncio
+    async def test_filter_accepts_contract_id(self):
+        session_filter = SessionFilterMixin()
+        data = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 15, 15, 0, tzinfo=timezone.utc)],
+                "open": [100.0],
+                "high": [101.0],
+                "low": [99.0],
+                "close": [100.5],
+                "volume": [1000],
+            }
+        )
+        result = await session_filter.filter_by_session(
+            data, SessionType.RTH, "CON.F.US.ES.H26"
+        )
+        assert len(result) == 1
+
+
+class TestSessionFilterErrorRecoveryContinued:
+    """Large-data recovery paths for SessionFilterMixin."""
+
+    @pytest.fixture
+    def session_filter(self):
+        return SessionFilterMixin()
 
     @pytest.mark.asyncio
     async def test_memory_pressure_handling(self, session_filter):

--- a/tests/utils/test_async_rw_lock.py
+++ b/tests/utils/test_async_rw_lock.py
@@ -1,0 +1,197 @@
+"""Tests for AsyncRWLock coordination, timeouts, and cancellation (#137)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from project_x_py.utils.lock_optimization import AsyncRWLock
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_concurrent_readers_are_allowed() -> None:
+    lock = AsyncRWLock("readers")
+    in_cs = 0
+    max_in_cs = 0
+    started = asyncio.Event()
+
+    async def reader() -> None:
+        nonlocal in_cs, max_in_cs
+        async with lock.read_lock():
+            in_cs += 1
+            max_in_cs = max(max_in_cs, in_cs)
+            started.set()
+            await asyncio.sleep(0.05)
+            in_cs -= 1
+
+    await asyncio.gather(reader(), reader(), reader())
+    assert max_in_cs == 3
+    assert lock.reader_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_readers_wait_for_active_writer() -> None:
+    lock = AsyncRWLock("writer-blocks-readers")
+    writer_holds = asyncio.Event()
+    reader_entered = asyncio.Event()
+
+    async def writer() -> None:
+        async with lock.write_lock():
+            writer_holds.set()
+            await asyncio.sleep(0.15)
+
+    async def reader() -> None:
+        await writer_holds.wait()
+        async with lock.read_lock():
+            reader_entered.set()
+
+    wtask = asyncio.create_task(writer())
+    rtask = asyncio.create_task(reader())
+    await writer_holds.wait()
+    await asyncio.sleep(0.03)
+    assert not reader_entered.is_set()
+    await asyncio.gather(wtask, rtask)
+    assert reader_entered.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_writer_waits_for_active_readers() -> None:
+    lock = AsyncRWLock("readers-block-writer")
+    reader_holds = asyncio.Event()
+    writer_entered = asyncio.Event()
+
+    async def reader() -> None:
+        async with lock.read_lock():
+            reader_holds.set()
+            await asyncio.sleep(0.15)
+
+    async def writer() -> None:
+        await reader_holds.wait()
+        async with lock.write_lock():
+            writer_entered.set()
+
+    rtask = asyncio.create_task(reader())
+    wtask = asyncio.create_task(writer())
+    await reader_holds.wait()
+    await asyncio.sleep(0.03)
+    assert not writer_entered.is_set()
+    await asyncio.gather(rtask, wtask)
+    assert writer_entered.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_waiting_writer_blocks_new_readers() -> None:
+    lock = AsyncRWLock("writer-preference")
+    reader1_holds = asyncio.Event()
+    writer_waiting = asyncio.Event()
+    writer_entered = asyncio.Event()
+    reader2_entered = asyncio.Event()
+
+    async def reader1() -> None:
+        async with lock.read_lock():
+            reader1_holds.set()
+            await asyncio.sleep(0.2)
+
+    async def writer() -> None:
+        await reader1_holds.wait()
+        writer_waiting.set()
+        async with lock.write_lock():
+            writer_entered.set()
+
+    async def reader2() -> None:
+        await writer_waiting.wait()
+        await asyncio.sleep(0.02)
+        async with lock.read_lock():
+            reader2_entered.set()
+
+    tasks = [
+        asyncio.create_task(reader1()),
+        asyncio.create_task(writer()),
+        asyncio.create_task(reader2()),
+    ]
+    await reader1_holds.wait()
+    await writer_waiting.wait()
+    await asyncio.sleep(0.05)
+    assert not reader2_entered.is_set()
+    await asyncio.gather(*tasks)
+    assert writer_entered.is_set()
+    assert reader2_entered.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_read_lock_timeout_raises() -> None:
+    lock = AsyncRWLock("read-timeout")
+
+    async def writer() -> None:
+        async with lock.write_lock():
+            await asyncio.sleep(1.0)
+
+    wtask = asyncio.create_task(writer())
+    await asyncio.sleep(0.02)
+    with pytest.raises(TimeoutError):
+        async with lock.read_lock(timeout=0.05):
+            raise AssertionError("reader must not enter while writer holds the lock")
+    wtask.cancel()
+    await asyncio.gather(wtask, return_exceptions=True)
+    stats = await lock.get_stats()
+    assert stats.timeouts >= 1
+    assert lock.reader_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_write_lock_timeout_raises() -> None:
+    lock = AsyncRWLock("write-timeout")
+
+    async def reader() -> None:
+        async with lock.read_lock():
+            await asyncio.sleep(1.0)
+
+    rtask = asyncio.create_task(reader())
+    await asyncio.sleep(0.02)
+    with pytest.raises(TimeoutError):
+        async with lock.write_lock(timeout=0.05):
+            raise AssertionError("writer must not enter while a reader holds the lock")
+    rtask.cancel()
+    await asyncio.gather(rtask, return_exceptions=True)
+    assert lock.reader_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_write_lock_is_reentrant() -> None:
+    lock = AsyncRWLock("reentrant-write")
+    nested = False
+    async with lock.write_lock():
+        async with lock.write_lock():
+            nested = True
+    assert nested is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cancelled_reader_releases_count() -> None:
+    lock = AsyncRWLock("cancel-reader")
+    entered = asyncio.Event()
+
+    async def reader() -> None:
+        async with lock.read_lock():
+            entered.set()
+            await asyncio.sleep(10)
+
+    task = asyncio.create_task(reader())
+    await entered.wait()
+    assert lock.reader_count == 1
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert lock.reader_count == 0
+
+    async with lock.write_lock(timeout=0.2):
+        pass


### PR DESCRIPTION
## Summary

Fixes #137. `DataManager.get_session_data("1min"|"5min", SessionType.RTH)` could wait forever on the bar-cache lock with no exception, which pinned `on_bar` and dropped later `NEW_BAR` events while the rest of the process still looked healthy.

This is **not** the silent WebSocket freeze from #97. The hang was inside `get_session_data` → `get_data` → `AsyncRWLock.read_lock()`:

- Readers never waited for an active or waiting writer (the lock was not a real RW lock).
- Writers busy-waited on `_reader_count` with no timeout.
- `get_data` returned a live DataFrame and `get_session_data` had no timeout/cancellation path.

## Changes

- **`AsyncRWLock`**: condition-based lock, writer preference, re-entrant writes, cancellable acquire, timeouts actually apply.
- **`get_data` / `get_session_data`**: copy bars under a bounded read lock (defaults 5s / 2s), filter after release. On timeout return the last successful snapshot or `None`.
- **`session_type` optional** on `get_session_data()` (uses `session_config`).
- **`resolve_session_product()`** maps `CON.F.US.MNQ.H26` / `MNQH26` to session calendars.
- Config: `data_lock_timeout`, `session_data_timeout`.
- Version **4.2.1**. Docs/README/CHANGELOG updated; `SessionType.BOTH` (it does not exist) removed from current docs.

## Tests

- `tests/utils/test_async_rw_lock.py` — reader/writer coordination, timeouts, reentrancy, cancellation.
- `tests/realtime_data_manager/test_get_session_data_hang.py` — timeout while write lock held, last-known snapshot, no lock held during filter, contract-id product resolve, cancellation.
- `tests/unit/test_session_filter.py::TestResolveSessionProduct`

Local: `uv run pytest -m "unit and not slow"` → **2717 passed**. `ruff check src/` and `mypy src/` clean.

## After merge

Tag `v4.2.1` and publish to PyPI (this PR is the version bump).